### PR TITLE
Single source package version

### DIFF
--- a/kbcstorage/__init__.py
+++ b/kbcstorage/__init__.py
@@ -1,6 +1,7 @@
 from pkg_resources import get_distribution, DistributionNotFound
 try:
-    __version__ = get_distribution('kbcstorage').version
+    release = get_distribution('kbcstorage').version
+    __version__ = '.'.join(release.split('.')[:2])
 except DistributionNotFound:
     # package is not installed
     pass

--- a/kbcstorage/__init__.py
+++ b/kbcstorage/__init__.py
@@ -1,1 +1,6 @@
-__version__ = '0.1.0'
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution('kbcstorage').version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'boto3',
         'requests'
-    ]
+    ],
     long_description=readme,
     license="MIT"
 )

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
-import kbcstorage
 
 with open("README.md") as f:
     readme = f.read()
 
 setup(
     name='kbcstorage',
-    version=kbcstorage.__version__,
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     url='https://github.com/keboola/sapi-python-client',
     download_url='https://github.com/keboola/sapi-python-client',
     packages=find_packages(),


### PR DESCRIPTION
The version of the package can be automatically extract from git, so you only need to manage version via `git tag`.

See [here](https://packaging.python.org/guides/single-sourcing-package-version/) and [here](https://pypi.python.org/pypi/setuptools_scm). This approach is clean and hassle free so I favour it.

It's a personal preference of mine to set up projects like this, so it's up to the rest of you if you want to merge it :)