### PR TITLE
New architecture & Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 sudo: required
 language: bash
 services:
-  - docker
+- docker
 before_script:
-  - docker-compose build sapi-python-client
-script: 
-  - docker-compose run --rm --entrypoint=flake8 sapi-python-client || true
-  - docker-compose run --rm -e KBC_TOKEN sapi-python-client -m unittest discover
+- docker-compose build sapi-python-client
+script:
+- docker-compose run --rm --entrypoint=flake8 sapi-python-client || true
+- docker-compose run --rm -e KBC_TOKEN sapi-python-client -m unittest discover
 after_success:
-  - docker images
+- docker images
 deploy:
   provider: script
   skip_cleanup: true
-  script: ./deploy.sh
+  script: "./deploy.sh"
   on:
-    tags: true  
+    tags: true
 notifications:
-  secure: "cK5gbRE+UtkU9tcAtI7uVU8/ioW5XyXH6H4IkpUE2gnzeYe1cWaSYt7JDJHJDI2THgaKqK7KIXmR4dZlEp7VjigoJiOc6nMIqMqCqOFediKPlFu7/J55w0zRZY/kYEZBjcirdVQJ1NhFYSxs3Fukrzvup631yN05CekJNQvi8y4xNJPLE7sH1JK/tF+WDG0COFNqeNkZnONgfVdA2eF+Wu9BH/YvGW0HvnfTjWowyZy1dQY5TRw4Rr50C4kpDQy8TU5o0IaG84FsONItsT+jTyc1Nal3ByM3clW1llTaKLmnQXwMWR6IeYfoScRASyTTdNoripgFnwj4HB64yFoCJUN0fg4h3Pn5/TU752XH+mDodmrK5C2KmYHsYq9LUtVaMItCimvRYqihWdpD7NN5Gcb3c0JxXa+a9//RsPPSFg9yMkObfBlIMeJrZwoEdakpMQhoLdADTOXKR0pK+i5qPWT07utYYdU25fkgRCvq5KeDBoGdUXUMmpUtRVP9uJQv0IQ7af70ov+nap9keNEcqxrb08UmnCMk+SzwFnVY3b0CaCUZPmiiZwklTb1o9nhLgkPV5Aya6cJRpdL3n5lE5tmXyoW/S/QptXopKValEGxJ2q+NpAndmv1tC33nR9Ap2FcZFAcdnVzVzP1e/pSXl+jB0ARcPmYgcXA4+t3v/2c="
+  slack:
+    rooms:
+      secure: IHfa2pHnjC/lY3H4062fTTz7y1CmHw0FbVtyxG8mMD9iuAbEIvgOs8+BRLFzqx6Baej1TnELFek7QCFdMV5SVDda7XMCOY5WLMoG1YoQ4UtnYE2mhvEsoKEu5C73rZ/OIm1jIihLFGpznwhq+ZSbPT2wiKfJglic87NW5XPsYE52XvZRQ3RY0dZpTxpXIdKOKUvcMK0FZfzDbkGHOB8GTVRNyaa1r4uI4XTyNW3c3l8sTOQo3l4rCtQXyMVqWIKXywxSfo7r+h1XPqrxpUtm+2d/B05bYRlD39OGR3O5LwK1YDFl7F3Dc9u503IhMs1p5gc3jRb4L1QCJXy0VcXgHPyaKMSnE6Ambja6S8oXXao167iR7qJ3sHgd1PAs48pSZPoqSvVB8K26X59l9jKf0xAqFm2tZVEOuYD2yGKoWpB4f201yTfVQaQ69P/lLFhao+kI2XuupCgyVTeuOFyc4fYS6k1ooJvFY8NPlhnCVW6xYJCfRcy0gYFXCAVgqpl6Icm4nMVQ66AU6tQckfuZK/7vfpw1SsfifeHLFLQp0AiXydS4ozhFYzejDxVnKH8a1S4ZGfvgPEVfc2xp5C8nJR8YJn9KA3V0JJ01foBofymWnB2QPLUQr3iaLbPsep3ixtjxTSTTjFWCv5kd6Sh193KcK/0RkHWs+1Tz0Lb+FZM=

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.6
 
 WORKDIR /code
 COPY . /code/
-RUN pip3 install --no-cache-dir flake8
+RUN pip3 install --no-cache-dir flake8 responses
 RUN python setup.py install
 ENTRYPOINT ["python"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Docker image with pre-installed library is also available, run it via:
 docker run -i -t quay.io/keboola/sapi-python-client
 ```
 
+## Tests
+
+```bash
+$ git clone https://github.com/keboola/sapi-python-client.git && cd sapi-python-client
+$ python setup.py test
+```
+
+
 Under development -- all contributions very welcome :)
 
 Kickstarted via https://gist.github.com/Halama/6006960 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/keboola/psapi-python-client.svg?branch=master)](https://travis-ci.org/keboola/sapi-python-client)
+
 # Python client for the Keboola Storage API
 
 ## Install
@@ -34,7 +36,13 @@ cl.get_table(tableId)
 
 ```
 
+## Docker image
+Docker image with pre-installed library is also available, run it via:
+
+```
+docker run -i -t quay.io/keboola/sapi-python-client
+```
+
 Under development -- all contributions very welcome :)
 
 Kickstarted via https://gist.github.com/Halama/6006960 
-.

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -58,7 +58,7 @@ class Endpoint:
         except requests.HTTPError:
             # Handle different error codes
             raise
-        finally:
+        else:
             return r.json()
 
     def post(self, *args, **kwargs):
@@ -82,7 +82,7 @@ class Endpoint:
         except requests.HTTPError:
             # Handle different error codes
             raise
-        finally:
+        else:
             return r.json()
 
     def put(self):

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -86,7 +86,7 @@ class Endpoint:
         finally:
             return r.json()
 
-    def _put(self):
+    def put(self):
         raise NotImplementedError
 
     def delete(self, *args, **kwargs):

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -37,16 +37,14 @@ class Endpoint:
         self.path = urljoin(root, extension)
         self.token = token
 
-    def _get(self, params=[], extra_headers={}):
+    def get(self, *args, **kwargs):
         """
-        Make a get request to the url of the endpoint extended with additional
-        params.
+        Construct a requests GET call with args and kwargs and process the
+        results.
 
         Args:
-            params (:obj:`list`): Is used to update the url of the request.
-                Default [].
-            extra_headers (:obj:`dict`): Is used to update the headers.
-                Default {}.
+            *args: Positional arguments to pass to the get request.
+            **kwargs: Key word arguments to pass to the get request.
 
         Returns:
             body: Response body parsed from json.
@@ -54,27 +52,23 @@ class Endpoint:
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
-        headers.update(extra_headers)
+        r = requests.get(*args, **kwargs)
+        try:
+            r.raise_for_status()
+        except requests.HTTPError:
+            # Handle different error codes
+            raise
+        finally:
+            return r.json()
 
-        url = self._extend(self.path, params)
-
-        r = requests.get(url, headers=headers)
-        r.raise_for_status()
-
-        return r.json()
-
-    def _post(self, body={}, params=[], extra_headers={}):
+    def post(self, *args, **kwargs):
         """
-        Make a post request to the endpoint url extended with params,
+        Construct a requests POST call with args and kwargs and process the
+        results.
 
         Args:
-            body (:obj:`dict`): key value pairs for the body of the HTTP
-                request. Default {}.
-            params (:obj:`list`): Is used to update the url of the request.
-                Default [].
-            extra_headers (:obj:`dict`): Is used to update the headers.
-                Default {}.
+            *args: Positional arguments to pass to the post request.
+            **kwargs: Key word arguments to pass to the post request.
 
         Returns:
             body: Response body parsed from json.
@@ -82,44 +76,40 @@ class Endpoint:
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
-        headers.update(headers)
-
-        url = self._extend(self.path, params)
-
-        r = requests.post(url, headers=headers, data=body)
+        r = requests.post(*args, **kwargs)
         r.raise_for_status()
-        return r.json()
+        try:
+            r.raise_for_status()
+        except requests.HTTPError:
+            # Handle different error codes
+            raise
+        finally:
+            return r.json()
 
     def _put(self):
         raise NotImplementedError
 
-    def _delete(self, params=[], extra_headers={}):
+    def delete(self, *args, **kwargs):
         """
-        Make a delete request to the endpoint.
+        Construct a requests DELETE call with args and kwargs and process the
+        result
 
         Args:
-            params (:obj:`list`): Is used to update the url of the request.
-                Default [].
-            extra_headers (:obj:`dict`): Is used to update the headers.
-                Default {}.
+            *args: Positional arguments to pass to the delete request.
+            **kwargs: Key word arguments to pass to the delete request.
+
+        Returns:
+            body: Response body parsed from json.
 
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
-        headers.update(extra_headers)
-
-        url = self._extend(self.path, params)
-
-        r = requests.delete(url, headers=headers)
-        r.raise_for_status()
+        r = requests.delete(*args, **kwargs)
+        try:
+            r.raise_for_status()
+        except requests.HTTPError:
+            # Handle different error codes
+            raise
 
     def _extend(self, base, parts):
         """

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -128,19 +128,3 @@ class Endpoint:
         except requests.HTTPError:
             # Handle different error codes
             raise
-
-    def _extend(self, base, parts):
-        """
-        Join the items in parts to base by forward slashes
-
-        Args:
-            base (:obj:`str`): The base string, eg.
-                'http://example.com/hello/'.
-            parts (:obj:`list`): The extensions, eg ['a', 'deeper', 'path'].
-
-        Returns:
-            joined (:obj:`str`): The parts joined to base by forward slash,
-                eg. 'http://example.com/hello/a/deeper/path'.
-        """
-        return '/'.join([base, *[str(part).strip('/') for part in parts if
-                         str(part).strip('/')]])

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -1,0 +1,139 @@
+"""
+Base classes for constructing the client.
+
+Primarily exposes a base Endpoint class which deduplicates functionality across
+various endpoints, such as tables, workspaces, jobs, etc. as described in the
+`Storage API documentation`.
+
+
+.. _Storage API documentation:
+    http://docs.keboola.apiary.io/
+"""
+from urllib.parse import urljoin
+
+import requests
+
+
+class Endpoint:
+    """
+    Base class for implementing a single endpoint related to a single entities
+    as described in the Storage API.
+
+    Attributes:
+        path (str): URL for this endpoint.
+        token (str): A key for the Storage API.
+    """
+    def __init__(self, root, extension, token):
+        """
+        Create an endpoint.
+
+        Args
+            root (str): Root url of API. eg.
+                "https://connection.keboola.com/v2/storage/"
+            extension (str): Extension of url for the endpoint. eg. "buckets"
+            token (str): A key for the Storage API. Can be found in the storage
+            console.
+        """
+        self.path = urljoin(root, extension)
+        self.token = token
+
+    def _get(self, params=[], extra_headers={}):
+        """
+        Make a get request to the url of the endpoint extended with additional
+        params.
+
+        Args:
+            params (:obj:`list`): Is used to update the url of the request.
+                Default [].
+            extra_headers (:obj:`dict`): Is used to update the headers.
+                Default {}.
+
+        Returns:
+            body: Response body parsed from json.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        headers = {'X-StorageApi-Token': self.token}
+        headers.update(extra_headers)
+
+        url = self._extend(self.path, params)
+
+        r = requests.get(url, headers=headers)
+        r.raise_for_status()
+
+        return r.json()
+
+    def _post(self, body={}, params=[], extra_headers={}):
+        """
+        Make a post request to the endpoint url extended with params,
+
+        Args:
+            body (:obj:`dict`): key value pairs for the body of the HTTP
+                request. Default {}.
+            params (:obj:`list`): Is used to update the url of the request.
+                Default [].
+            extra_headers (:obj:`dict`): Is used to update the headers.
+                Default {}.
+
+        Returns:
+            body: Response body parsed from json.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        headers = {
+            'X-StorageApi-Token': self.token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        headers.update(headers)
+
+        url = self._extend(self.path, params)
+
+        r = requests.post(url, headers=headers, data=body)
+        r.raise_for_status()
+        return r.json()
+
+    def _put(self):
+        raise NotImplementedError
+
+    def _delete(self, params=[], extra_headers={}):
+        """
+        Make a delete request to the endpoint.
+
+        Args:
+            params (:obj:`list`): Is used to update the url of the request.
+                Default [].
+            extra_headers (:obj:`dict`): Is used to update the headers.
+                Default {}.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        headers = {
+            'X-StorageApi-Token': self.token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        headers.update(extra_headers)
+
+        url = self._extend(self.path, params)
+
+        r = requests.delete(url, headers=headers)
+        r.raise_for_status()
+
+    def _extend(self, base, parts):
+        """
+        Join the items in parts to base by forward slashes
+
+        Args:
+            base (:obj:`str`): The base string, eg.
+                'http://example.com/hello/'.
+            parts (:obj:`list`): The extensions, eg ['a', 'deeper', 'path'].
+
+        Returns:
+            joined (:obj:`str`): The parts joined to base by forward slash,
+                eg. 'http://example.com/hello/a/deeper/path'.
+        """
+        parts.insert(0, base)
+        return '/'.join([str(part).strip('/') for part in parts if
+                         str(part).strip('/')])

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -9,8 +9,6 @@ various endpoints, such as tables, workspaces, jobs, etc. as described in the
 .. _Storage API documentation:
     http://docs.keboola.apiary.io/
 """
-from urllib.parse import urljoin
-
 import requests
 
 

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -20,21 +20,23 @@ class Endpoint:
     as described in the Storage API.
 
     Attributes:
-        path (str): URL for this endpoint.
+        base_url (str): The base URL for this endpoint.
         token (str): A key for the Storage API.
     """
-    def __init__(self, root, extension, token):
+    def __init__(self, root_url, path_component, token):
         """
         Create an endpoint.
 
         Args
-            root (str): Root url of API. eg.
+            root_url (str): Root url of API. eg.
                 "https://connection.keboola.com/v2/storage/"
-            extension (str): Extension of url for the endpoint. eg. "buckets"
+            path_component (str): The section of the path specific to the
+                endpoint. eg. "buckets"
             token (str): A key for the Storage API. Can be found in the storage
-            console.
+                console.
         """
-        self.path = urljoin(root, extension)
+        self.base_url = '{}/{}'.format(root_url.strip('/'),
+                                       path_component.strip('/'))
         self.token = token
 
     def get(self, *args, **kwargs):

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -87,6 +87,22 @@ class Endpoint:
             return r.json()
 
     def put(self):
+        """
+        **Not implemented**
+
+        Construct a requests PUT call with args and kwargs and process the
+        result
+
+        Args:
+            *args: Positional arguments to pass to the put request.
+            **kwargs: Key word arguments to pass to the put request.
+
+        Returns:
+            body: Response body parsed from json.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
         raise NotImplementedError
 
     def delete(self, *args, **kwargs):

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -77,7 +77,6 @@ class Endpoint:
             requests.HTTPError: If the API request fails.
         """
         r = requests.post(*args, **kwargs)
-        r.raise_for_status()
         try:
             r.raise_for_status()
         except requests.HTTPError:
@@ -126,3 +125,4 @@ class Endpoint:
         except requests.HTTPError:
             # Handle different error codes
             raise
+        # Should delete return something on success?

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -1,0 +1,143 @@
+"""
+Manages calls to the Storage API relating to buckets
+
+Full documentation `here`.
+
+.. _here:
+    http://docs.keboola.apiary.io/#reference/buckets/
+"""
+from kbcstorage.base import Endpoint
+
+
+class Buckets(Endpoint):
+    """
+    Buckets Endpoint
+    """
+    def __init__(self, root_url, token):
+        """
+        Create a Workspaces endpoint.
+
+        Args:
+            url (:obj:`str`): The base url for the API.
+            token (:obj:`str`): A storage API key.
+        """
+        super().__init__(root_url, 'buckets', token)
+
+    def list(self):
+        """
+        Get all job details.
+
+        Returns:
+            response_body: The parsed json from the HTTP response.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        headers = {'X-StorageApi-Token': self.token}
+
+        return self.get(self.base_url, headers=headers)
+
+    def detail(self, bucket_id):
+        """
+        Retrieves information about a given bucket.
+
+        Args:
+            bucket_id (int or str): The id of the bucket.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        url = '{}/{}'.format(self.base_url, bucket_id)
+        headers = {'X-StorageApi-Token': self.token}
+
+        return self.get(url, headers=headers)
+
+    def create(self, name, stage='in', description='', backend=None):
+        """
+        Create a new bucket.
+
+        Args:
+            name (str): The new bucket name (only alphanumeric and underscores)
+            stage (str): The new bucket stage. Can be one of ``in`` or ``out``.
+                Default ``in``.
+            description (str): The new bucket description.
+            backend (str): The new bucket backend. Cand be one of
+                ``snowflake``, ``redshift`` or ``mysql``. Default determined by
+                project settings.
+        Returns:
+            response_body: The parsed json from the HTTP response.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        # Separating create and link into two distinct functions...
+        headers = {
+            'X-StorageApi-Token': self.token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        # Need to check args...
+        body = {
+            'name': name,
+            'stage': stage,
+            'description': description,
+            'backend': backend
+        }
+
+        return self.post(self.base_url, headers=headers, data=body)
+
+    def delete(self, bucket_id, force=False):
+        """
+        Delete a bucket referenced by ``bucket_id``.
+
+        By default, only empty buckets without dependencies (aliases etc) can
+        be deleted. The optional ``force`` parameter allows for the deletion
+        of non-empty buckets.
+
+        Args:
+            bucket_id (str or int): The id of the bucket to be deleted.
+            force (bool): If ``True``, deletes the bucket even if it is not
+                empty. Default ``False``.
+        """
+        # How does the API handle it when force == False and the bucket is non-
+        # empty?
+        url = '{}/{}'.format(self.base_url, bucket_id)
+        headers = {'X-StorageApi-Token': self.token}
+        params = {'force': force}
+        super().delete(url, headers=headers, params=params)
+
+    def link(self, *args, **kwargs):
+        """
+        **Not implemented**
+
+        Link an existing bucket from another project.
+
+        Creates a new bucket which contains the contents of a shared bucket in
+        a source project. Linking a bucket from another project is only
+        possible if it has been enabled in the project.
+        """
+        raise NotImplementedError
+
+    def share(self, *args, **kwargs):
+        """
+        **Not implemented**
+
+        Enable sharing of a bucket.
+
+        The bucket will be shared to the entire organisation to which the
+        project belongs. It may then be shared to any project of that
+        organization. This operation is only available to administrator tokens.
+        """
+        raise NotImplementedError
+
+    def unshare(self, *args, **kwargs):
+        """
+        **Not implemented**
+
+        Stop sharing a bucket.
+
+        The bucket must not be linked to other projects. To unshare an already
+        linked bucket, the links must first be deleted - use ``delete`` on the
+        bucket in the linking project. This operation is only available for
+        administrator tokens.
+        """
+        raise NotImplementedError

--- a/kbcstorage/client.py
+++ b/kbcstorage/client.py
@@ -1,228 +1,33 @@
-import boto3
-from botocore.exceptions import ClientError
-import os
-import requests
-import string
-import time
+"""
+Entry point for the Storage API client.
+"""
 
+from kbcstorage.buckets import Buckets
+from kbcstorage.workspaces import Workspaces
+from kbcstorage.jobs import Jobs
 
-class HttpHelper:
-    api_url = "https://connection.keboola.com"
-    api_version = 'v2'
-    user_agent = "Keboola StorageApi Python Client/v2"
-
-    def __init__(self, token, api_url=None):
-        self.token = token
-        if api_url is not None:
-            self.api_url = api_url
-
-    def tokenheader(self):
-        return {
-            'User-Agent': self.user_agent,
-            'X-StorageApi-Token': self.token
-        }
-
-    def getRequest(self, url, params = None):
-        if params == None:
-            params = []
-        resp = self.getAbsUrlRequest(url, params)
-        resp.raise_for_status()
-        return resp.json()
-
-    def postRequest(self, url, params):
-        resp = requests.post(self.api_url + '/' + self.api_version + '/' + url, headers=self.tokenheader(), data=params)
-        resp.raise_for_status()
-        return resp.json()
-
-    def getAbsUrlRequest(self, url, params):
-        return requests.get(self.api_url + '/' + self.api_version + '/' + url, headers=self.tokenheader(), params=params)
-
-    def deleteRequest(self, url, params):
-        resp = requests.delete(self.api_url + '/' + self.api_version + '/' + url, headers=self.tokenheader(), data=params)
-        resp.raise_for_status()
 
 class Client:
-    def __init__(self, token, api_url=None):
+    """
+    Storage API Client.
+    """
+    def __init__(self, api_domain, token):
+        """
+        Initialise a client.
+
+        Args:
+            api_domain (str): The domain on which the API sits. eg.
+                "https://connection.keboola.com".
+            token (str): A storage API key.
+        """
+        api_version_string = 'v2'
+        api_path_component = 'storage'
+
+        self.root_url = '{}/{}/{}'.format(api_domain,
+                                          api_version_string,
+                                          api_path_component)
         self.token = token
-        self.http = HttpHelper(token, api_url)
 
-    def list_buckets(self):
-        return self.http.getRequest('storage/buckets')
-
-    def list_bucket_tables(self, bucket):
-        return self.http.getRequest('storage/buckets/' + bucket + '/tables')
-
-    def files_prepare(self, name, sizeBytes):
-        payload = {'name': name, 'sizeBytes': sizeBytes, 'notify': False}
-        return self.http.postRequest('storage/files/prepare', payload)
-
-    def files_upload(self, path):
-        fileObject = open(path, 'rb')
-        fileResource = self.files_prepare(os.path.basename(path), os.path.getsize(path))
-        uploadParams = fileResource['uploadParams']
-        params = {
-            'key': uploadParams['key'],
-            'acl': uploadParams['acl'],
-            'signature': uploadParams['signature'],
-            'policy': uploadParams['policy'],
-            'AWSAccessKeyId': uploadParams['AWSAccessKeyId']
-        }
-        files = {'file': fileObject}
-        requests.post(uploadParams['url'], data=params, files=files)
-        return fileResource
-
-    def bucket_exists(self, bucket_id):
-        try:
-            self.http.getRequest('storage/buckets/' + bucket_id)
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
-                return False
-            else:
-                raise
-        return True
-
-    def table_exists(self, tableId):
-        try:
-            resp = self.http.getRequest('storage/tables/' + tableId)
-            return True
-        except requests.exceptions.HTTPError as e:
-            return False
-
-    def get_table(self, tableId):
-        return self.http.getRequest('storage/tables/' + tableId)
-
-    def get_bucket(self, bucketId):
-        return self.http.getRequest('storage/buckets/' + bucketId)
-
-    def load_table_async(self, tableId, options = None):
-        opts = self.prepare_options(options)
-        if "federationToken" not in opts:
-            opts["federationToken"] = 1
-        return self.http.postRequest("storage/tables/" + tableId + "/export-async", opts)
-
-    def get_job_status(self, url):
-        resp = self.http.getAbsUrlRequest(url, [])
-        return resp.json()
-
-    def get_file_info(self, fileId, federationToken = "1"):
-        return self.http.getRequest("storage/files/" + str(fileId), {"federationToken": federationToken})
-
-    def prepare_options(self, options = None):
-        if options is None:
-            options = {}
-        # which parameters are allowed
-        params = ["limit", "changedSince", "changedUntil", "whereColumn", "whereValues"]
-        opts = {}
-        for val in params:
-            if val in options:
-                opts[val] = options[val]
-
-        if "columns" in options:
-            opts["columns"] = string.split(options["columns"], ",")
-
-        if "whereValues" in options:
-            for val in options["whereValues"]:
-                opts["whereValies[" + val + "]"] = options["whereValues"][val]
-                #opts[[paste0("whereValues[", i - 1, "]")]] < - options[["whereValues"]][i]
-
-        return opts
-
-    def get_table_data(self, tableId, localFile, options = None):
-        resp = self.load_table_async(tableId, options)
-        retries = 1
-        while True:
-            job = self.get_job_status(resp["url"])
-            if job["status"] == "success":
-                break
-            time.sleep(2 ^ retries)
-            retries = retries + 1
-            if job["status"] != "waiting" and job["status"] != "processing":
-                raise Exception("Job status: " + job["status"] + " - " + job["error"]["message"] +  " {" + job["error"]["exceptionId"] + ")")
-
-        table = self.get_table(tableId)
-        fileInfo = self.get_file_info(job["results"]["file"]["id"])
-        s3 = boto3.resource(
-            's3',
-            aws_access_key_id=fileInfo["credentials"]["AccessKeyId"],
-            aws_secret_access_key=fileInfo["credentials"]["SecretAccessKey"],
-            aws_session_token=fileInfo["credentials"]["SessionToken"]
-        )
-
-        if fileInfo["isSliced"]:
-            manifest = self.http.getAbsUrlRequest(fileInfo["url"], []).json()
-            fileNames = []
-            for entry in manifest["entries"]:
-                fullPath = entry["url"]
-                fileName = fullPath.rsplit("/", 1)[1]
-                fileNames.append(fileName)
-                splittedPath = string.split(fullPath, "/")
-                fileKey = "/".join(splittedPath[3:])
-                bucket = s3.Bucket(fileInfo["s3Path"]["bucket"])
-                try:
-                    bucket.download_file(fileKey, fileName)
-                except ClientError as e:
-                    if e.response['Error']['Code'] == "404":
-                        print("Could not find the object in s3")
-                    else:
-                        raise
-
-            # merge the downloaded files
-            with open(localFile, 'w') as outfile:
-                for fileName in fileNames:
-                    with open(fileName) as infile:
-                        for line in infile:
-                            outfile.write(line)
-                    os.remove(fileName)
-
-        else:
-            # single file is friendlier
-            bucket = s3.Bucket(fileInfo["s3Path"]["bucket"])
-            bucket.download_file(fileInfo["s3Path"]["key"], localFile)
-
-
-    def save_table(self, tableName, bucket, localFilePath, options = None):
-
-        if options is None:
-            options = {}
-
-        tableId = bucket + "." + tableName
-        postUrl = "storage/buckets/" + bucket + "/tables-async"
-        if self.table_exists(tableId):
-            postUrl = "storage/tables/" + tableId + "/import-async"
-
-        resource = self.files_upload(localFilePath)
-        opts = {
-            "bucketId": bucket,
-            "name": tableName,
-            "dataFileId": resource["id"]
-        }
-        opts['delimeter'] = options["delimeter"] if "delimeter" in options else ","
-        opts['enclosure'] = options["enclosure"] if "enclosure" in options else '"'
-        opts['escapedBy'] = options["escapedBy"] if "escapedBy" in options else None
-        opts['primaryKey'] = options["primaryKey"] if "primaryKey" in options else None
-        opts['incremental'] = options["incremental"] if "incremental" in options else None
-
-        jobres = self.http.postRequest(postUrl, opts)
-
-        retries = 1
-        while True:
-            job = self.get_job_status(jobres["url"])
-            if job["status"] == "success":
-                break
-            time.sleep(2 ^ retries)
-            retries = retries + 1
-            if job["status"] != "waiting" and job["status"] != "processing":
-                raise Exception(
-                    "Job status: " + job["status"] + " - " + job["error"]["message"]
-                    + " {" + job["error"]["exceptionId"] + ")"
-                )
-        return True
-
-    def drop_bucket(self, bucket_id, options=None):
-        return self.http.deleteRequest('storage/buckets/' + str(bucket_id), options)
-
-    def create_bucket(self, name, stage, description='', backend=None):
-        data = {'name': name, 'stage': stage, 'description': description}
-        if backend is not None:
-            data['backend'] = backend
-        return self.http.postRequest('storage/buckets/', data)['id']
+        self.buckets = Buckets(self.root_url, self.token)
+        self.workspaces = Workspaces(self.root_url, self.token)
+        self.jobs = Jobs(self.root_url, self.token)

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -1,0 +1,67 @@
+"""
+"""
+import requests
+
+from kbcstorage.base import Endpoint
+
+
+class Jobs(Endpoint):
+    """
+    Jobs are objects that manage asynchronous tasks, these are all
+    potentially long-running actions such as loading table data,
+    snapshotting, table structure modifications. Jobs are created by
+    actions on target resources.
+
+    A job has four available statuses:
+
+    ``waiting``
+        The job is in the queue and is waiting for execution.
+
+    ``processing``
+        The job is being processed by a worker.
+
+    ``success``
+        The job is done with a success.
+
+    ``error``
+        The job is done with an error.
+    """
+
+    def __init__(self, root_url, token):
+        """
+        Create a Jobs endpoint.
+
+        Args:
+            url (:obj:`str`): The base url for the API.
+            token (:obj:`str`): A storage API key.
+        """
+        super().__init__(root_url, 'jobs', token)
+
+    def list(self):
+        """
+        List all jobs details.
+
+        Returns:
+            response_body: The json from the HTTP response.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        headers = {'X-StorageApi-Token': self.token}
+
+        return self.get(self.base_url, headers=headers)
+
+    def detail(self, job_id):
+        """
+        Retrieves information about a given job.
+
+        Args:
+            job_id (int or str): The id of the job.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        headers = {'X-StorageApi-Token': self.token}
+        url = '{}/{}'.format(self.base_url, job_id)
+
+        return self.get(url, headers=headers)

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -8,8 +8,6 @@ Full documentation `here`.
 """
 import time
 
-import requests
-
 from kbcstorage.base import Endpoint
 
 
@@ -119,8 +117,8 @@ class Jobs(Endpoint):
 
     def block_for_success(self, job_id, d=1):
         """
-        Poll the API until the job is completed, then return ``True`` if the job
-        is succesful, else ``False``.
+        Poll the API until the job is completed, then return ``True`` if the
+        job is succesful, else ``False``.
 
         Args:
             job_id (int or str): The id of the job
@@ -128,7 +126,7 @@ class Jobs(Endpoint):
                 Default 1.
 
         Returns:
-            success (bool): True if the job status is success, else False. 
+            success (bool): True if the job status is success, else False.
 
         Raises:
             requests.HTTPError: If any API request fails.

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -1,4 +1,10 @@
 """
+Manages calls to the Storage API relating to jobs.
+
+Full documentation `here`.
+
+.. _here:
+    http://docs.keboola.apiary.io/#reference/jobs/
 """
 import time
 

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -19,9 +19,6 @@ def _make_body(mapping):
         mapping(:obj:`dict`): Keys contain the full names of the tables to
             be loaded (ie. 'in.c-bucker.table_name') and values contain the
             aliases to which they will be loaded (ie. 'table_name').
-        preserve(bool): If True, does not clear the workspace of existing
-            tables. If False, clears the workspace of tables before loading.
-            Default False.
     """
     body = {}
     template = 'input[{0}][{1}]'
@@ -52,6 +49,9 @@ class Workspaces(Endpoint):
 
         Returns:
             response_body: The json from the HTTP response.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
         """
         headers = {'X-StorageApi-Token': self.token}
         return self.get(self.base_url, headers=headers)
@@ -62,6 +62,12 @@ class Workspaces(Endpoint):
 
         Note that the password to the workspace can only be retrieved when the
         workspace is created.
+
+        Args:
+            workspace_id (int or str): The id of the workspace.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
         """
         headers = {'X-StorageApi-Token': self.token}
         url = '{}/{}'.format(self.base_url, workspace_id)
@@ -73,9 +79,12 @@ class Workspaces(Endpoint):
 
         Args:
             backend (:obj:`str`): The type of engine for the workspace.
-                'redshift' or 'snowflake'
+                'redshift' or 'snowflake'. Default redshift.
             timeout (int): The timeout, in seconds, for SQL statements.
                 Only supported by snowflake backends.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
         """
         headers = {
             'X-StorageApi-Token': self.token,
@@ -85,6 +94,7 @@ class Workspaces(Endpoint):
             'backend': backend,
             'statementTimeoutSeconds': timeout
         }
+
         return self.post(self.base_url, data=body, headers=headers)
 
     def delete(self, workspace_id):
@@ -92,18 +102,32 @@ class Workspaces(Endpoint):
         Deletes a workspace.
 
         This also irreversibly removes workspace content.
+
+        Args:
+            workspace_id (int or str): The id of the workspace to be deleted.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
         """
         headers = {
             'X-StorageApi-Token': self.token,
             'Content-Type': 'application/x-www-form-urlencoded'
         }
         url = '{}/{}'.format(self.base_url, workspace_id)
+
         # This shadows the superclass...
         return super().delete(url, headers=headers)
 
     def reset_password(self, workspace_id):
         """
         Generate a new password for the workspace.
+
+        Args:
+            workspace_id (int or str): The id of the workspace for which the
+                password should be reset.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
         """
         headers = {
             'X-StorageApi-Token': self.token,
@@ -117,10 +141,15 @@ class Workspaces(Endpoint):
         Load tabes from storage into a workspace.
 
         Args:
+            workspace_id (int or str): The id of the workspace to which to load
+                the tables.
             table_mapping (:obj:`dict`): Source table names mapped to
                 destination table names.
             preserve (bool): If False, drop tables, else keep tables in
                 workspace.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
 
         Todo:
             * Column data types.
@@ -132,4 +161,5 @@ class Workspaces(Endpoint):
         body = _make_body(table_mapping)
         body['preserve'] = preserve
         url = '{}/{}/load'.format(self.base_url, workspace_id)
+
         return self.post(url, data=body, headers=headers)

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -36,7 +36,7 @@ class Workspaces(Endpoint):
     """
     Workspaces Endpoint
     """
-    def __init__(self, url, token):
+    def __init__(self, root_url, token):
         """
         Create a Workspaces endpoint.
 
@@ -44,7 +44,7 @@ class Workspaces(Endpoint):
             url (:obj:`str`): The base url for the API.
             token (:obj:`str`): A storage API key.
         """
-        super().__init__(url, 'workspaces', token)
+        super().__init__(root_url, 'workspaces', token)
 
     def list(self):
         """
@@ -54,7 +54,7 @@ class Workspaces(Endpoint):
             response_body: The json from the HTTP response.
         """
         headers = {'X-StorageApi-Token': self.token}
-        return self.get(self.path, headers=headers)
+        return self.get(self.base_url, headers=headers)
 
     def detail(self, workspace_id):
         """
@@ -64,7 +64,7 @@ class Workspaces(Endpoint):
         workspace is created.
         """
         headers = {'X-StorageApi-Token': self.token}
-        url = '{}/{}'.format(self.path, workspace_id)
+        url = '{}/{}'.format(self.base_url, workspace_id)
         return self.get(url, headers=headers)
 
     def create(self, backend=None, timeout=None):
@@ -85,7 +85,7 @@ class Workspaces(Endpoint):
             'backend': backend,
             'statementTimeoutSeconds': timeout
         }
-        return self.post(self.path, data=body, headers=headers)
+        return self.post(self.base_url, data=body, headers=headers)
 
     def delete(self, workspace_id):
         """
@@ -97,7 +97,7 @@ class Workspaces(Endpoint):
             'X-StorageApi-Token': self.token,
             'Content-Type': 'application/x-www-form-urlencoded'
         }
-        url = '{}/{}'.format(self.path, workspace_id)
+        url = '{}/{}'.format(self.base_url, workspace_id)
         # This shadows the superclass...
         return super().delete(url, headers=headers)
 
@@ -109,7 +109,7 @@ class Workspaces(Endpoint):
             'X-StorageApi-Token': self.token,
             'Content-Type': 'application/x-www-form-urlencoded'
         }
-        url = '{}/{}/password'.format(self.path, workspace_id)
+        url = '{}/{}/password'.format(self.base_url, workspace_id)
         return self.post(url, headers=headers)
 
     def load_tables(self, workspace_id, table_mapping, preserve=None):
@@ -131,5 +131,5 @@ class Workspaces(Endpoint):
         }
         body = _make_body(table_mapping)
         body['preserve'] = preserve
-        url = '{}/{}/load'.format(self.path, workspace_id)
+        url = '{}/{}/load'.format(self.base_url, workspace_id)
         return self.post(url, data=body, headers=headers)

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -1,0 +1,112 @@
+"""
+Manages workspace requests to the API.
+
+Full documentation `here`.
+
+.. _here:
+    http://docs.keboola.apiary.io/#reference/workspaces/
+"""
+
+from kbcstorage.base import Endpoint
+
+
+def _make_body(mapping):
+    """
+    Given a dict mapping Keboola tables to aliases, construct the body of
+    the HTTP request to load said tables.
+
+    Args:
+        mapping(:obj:`dict`): Keys contain the full names of the tables to
+            be loaded (ie. 'in.c-bucker.table_name') and values contain the
+            aliases to which they will be loaded (ie. 'table_name').
+        preserve(bool): If True, does not clear the workspace of existing
+            tables. If False, clears the workspace of tables before loading.
+            Default False.
+    """
+    body = {}
+    template = 'input[{0}][{1}]'
+    for i, (k, v) in enumerate(mapping.items()):
+        body[template.format(i, 'source')] = k
+        body[template.format(i, 'destination')] = v
+
+    return body
+
+
+class Workspaces(Endpoint):
+    """
+    Workspaces Endpoint
+    """
+    def __init__(self, url, token):
+        """
+        Create a Workspaces endpoint.
+
+        Args:
+            url (:obj:`str`): The base url for the API.
+            token (:obj:`str`): A storage API key.
+        """
+        super().__init__(url, 'workspaces', token)
+
+    def list(self):
+        """
+        List the details of all workspaces in the project.
+
+        Returns:
+            response_body: The json from the HTTP response.
+        """
+        return self._get()
+
+    def detail(self, workspace_id):
+        """
+        Retrieves information about a given workspace.
+
+        Note that the passowrd to the workspace can only be retrieved when the
+        workspace is created.
+        """
+        return self._get(params=[workspace_id])
+
+    def create(self, backend=None, timeout=None):
+        """
+        Create a new Workspace and return the credentials.
+
+        Args:
+            backend (:obj:`str`): The type of engine for the workspace.
+                'redshift' or 'snowflake'
+            timeout (int): The timeout, in seconds, for SQL statements.
+                Only supported by snowflake backends.
+        """
+        body = {
+            'backend': backend,
+            'statementTimeoutSeconds': timeout
+        }
+        return self._post(body=body)
+
+    def delete(self, workspace_id):
+        """
+        Deletes a workspace.
+
+        This also irreversibly removes workspace content.
+        """
+        return self._delete(params=[workspace_id])
+
+    def reset_password(self, workspace_id):
+        """
+        Generate a new password for the workspace.
+        """
+        return self._post(params=[workspace_id, 'password'])
+
+    def load_tables(self, workspace_id, table_mapping, preserve=None):
+        """
+        Load tabes from storage into a workspace.
+
+        Args:
+            table_mapping (:obj:`dict`): Source table names mapped to
+                destination table names.
+            preserve (bool): If False, drop tables, else keep tables in
+                workspace.
+
+        Todo:
+            * Column data types.
+        """
+        body = _make_body(table_mapping)
+        body['preserve'] = preserve
+        return self._post(body, params=[workspace_id, 'load'])

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -1,12 +1,11 @@
 """
-Manages workspace requests to the API.
+Manages calls to the Storage API relating to workspaces.
 
 Full documentation `here`.
 
 .. _here:
     http://docs.keboola.apiary.io/#reference/workspaces/
 """
-
 from kbcstorage.base import Endpoint
 
 

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -53,16 +53,19 @@ class Workspaces(Endpoint):
         Returns:
             response_body: The json from the HTTP response.
         """
-        return self._get()
+        headers = {'X-StorageApi-Token': self.token}
+        return self.get(self.path, headers=headers)
 
     def detail(self, workspace_id):
         """
         Retrieves information about a given workspace.
 
-        Note that the passowrd to the workspace can only be retrieved when the
+        Note that the password to the workspace can only be retrieved when the
         workspace is created.
         """
-        return self._get(params=[workspace_id])
+        headers = {'X-StorageApi-Token': self.token}
+        url = '{}/{}'.format(self.path, workspace_id)
+        return self.get(url, headers=headers)
 
     def create(self, backend=None, timeout=None):
         """
@@ -74,11 +77,15 @@ class Workspaces(Endpoint):
             timeout (int): The timeout, in seconds, for SQL statements.
                 Only supported by snowflake backends.
         """
+        headers = {
+            'X-StorageApi-Token': self.token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
         body = {
             'backend': backend,
             'statementTimeoutSeconds': timeout
         }
-        return self._post(body=body)
+        return self.post(self.path, data=body, headers=headers)
 
     def delete(self, workspace_id):
         """
@@ -86,13 +93,24 @@ class Workspaces(Endpoint):
 
         This also irreversibly removes workspace content.
         """
-        return self._delete(params=[workspace_id])
+        headers = {
+            'X-StorageApi-Token': self.token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        url = '{}/{}'.format(self.path, workspace_id)
+        # This shadows the superclass...
+        return super().delete(url, headers=headers)
 
     def reset_password(self, workspace_id):
         """
         Generate a new password for the workspace.
         """
-        return self._post(params=[workspace_id, 'password'])
+        headers = {
+            'X-StorageApi-Token': self.token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        url = '{}/{}/password'.format(self.path, workspace_id)
+        return self.post(url, headers=headers)
 
     def load_tables(self, workspace_id, table_mapping, preserve=None):
         """
@@ -107,6 +125,11 @@ class Workspaces(Endpoint):
         Todo:
             * Column data types.
         """
+        headers = {
+            'X-StorageApi-Token': self.token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
         body = _make_body(table_mapping)
         body['preserve'] = preserve
-        return self._post(body, params=[workspace_id, 'load'])
+        url = '{}/{}/load'.format(self.path, workspace_id)
+        return self.post(url, data=body, headers=headers)

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,13 @@ setup(
     setup_requires=['setuptools_scm'],
     url='https://github.com/keboola/sapi-python-client',
     download_url='https://github.com/keboola/sapi-python-client',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     install_requires=[
         'boto3',
         'requests'
     ],
+    test_suite='tests',
+    tests_require=['responses'],
     long_description=readme,
     license="MIT"
 )

--- a/tests/bucket_responses.py
+++ b/tests/bucket_responses.py
@@ -1,0 +1,63 @@
+list_response = [
+    {
+        "uri": "https://connection.keboola.com/v2/storage/buckets/in.c-main",
+        "id": "in.c-main",
+        "name": "c-main",
+        "stage": "in",
+        "description": "Main user storage",
+        "tables": ("https://connection.keboola.com/v2/storage/buckets/"
+                   "in.c-main/tables"),
+        "backend": "snowflake"
+    },
+    {
+        "uri": ("https://connection.keboola.com/v2/storage/buckets/"
+                "in.c-organizationData"),
+        "id": "in.c-organizationData",
+        "name": "c-organizationData",
+        "stage": "in",
+        "description": "Source bucket description",
+        "tables": ("https://connection.keboola.com/v2/storage/buckets/"
+                   "in.c-organizationData/tables"),
+        "backend": "snowflake",
+        "isReadonly": True,
+        "sourceBucket": {
+            "id": "in.c-main",
+            "name": "c-main",
+            "description": "Organization shared data",
+            "project": {
+                "id": 123,
+                "name": "Project name"
+            }
+        }
+    }
+]
+
+detail_response = {
+  "uri": "https://connection.keboola.com/v2/storage/buckets/in.c-ga",
+  "id": "in.c-ga",
+  "name": "c-ga",
+  "stage": "in",
+  "description": "Google Analytics",
+  "tables": "https://connection.keboola.com/v2/storage/buckets/in.c-ga/tables",
+  "backend": "mysql"
+}
+
+create_response = {
+  "uri": ("https://connection.keboola.com/v2/storage/buckets/"
+          "in.c-my-new-bucket"),
+  "id": "in.c-my-new-bucket",
+  "name": "c-my-new-bucket",
+  "stage": "in",
+  "description": "Some Description",
+  "tables": ("https://connection.keboola.com/v2/storage/buckets/"
+             "in.c-my-new-bucket/tables"),
+  "created": "2017-02-13T12:01:05+0100",
+  "lastChangeDate": None,
+  "isReadOnly": False,
+  "dataSizeBytes": 0,
+  "rowsCount": 0,
+  "isMaintenance": False,
+  "backend": "snowflake",
+  "sharing": None,
+  "attributes": []
+}

--- a/tests/job_responses.py
+++ b/tests/job_responses.py
@@ -1,0 +1,73 @@
+list_response = [
+  {
+    "id": 22077337,
+    "status": "success",
+    "url": "https://connection.keboola.com/v2/storage/jobs/22077337",
+    "tableId": None,
+    "operationName": "workspaceLoad",
+    "operationParams": {
+      "workspaceId": "78423",
+      "preserve": False,
+      "input": [
+        {
+          "source": "in.c-application-testing.cashier-data",
+          "destination": "my-table"
+        }
+      ],
+      "queue": "main_fast"
+    },
+    "createdTime": "2017-02-13T16:41:18+0100",
+    "startTime": "2017-02-13T16:41:18+0100",
+    "endTime": "2017-02-13T16:42:00+0100",
+    "runId": None,
+    "results": None,
+    "creatorToken": {
+      "id": "27978",
+      "description": "ondrej.popelka@keboola.com"
+    },
+    "metrics": {
+      "inCompressed": False,
+      "inBytes": 0,
+      "inBytesUncompressed": 0,
+      "outCompressed": True,
+      "outBytes": 7168,
+      "outBytesUncompressed": 0
+    }
+  }
+]
+
+detail_response = {
+  "id": 22077337,
+  "status": "success",
+  "url": "https://connection.keboola.com/v2/storage/jobs/22077337",
+  "tableId": None,
+  "operationName": "workspaceLoad",
+  "operationParams": {
+    "workspaceId": "78423",
+    "preserve": False,
+    "input": [
+      {
+        "source": "in.c-application-testing.cashier-data",
+        "destination": "my-table"
+      }
+    ],
+    "queue": "main_fast"
+  },
+  "createdTime": "2017-02-13T16:41:18+0100",
+  "startTime": "2017-02-13T16:41:18+0100",
+  "endTime": "2017-02-13T16:42:00+0100",
+  "runId": None,
+  "results": None,
+  "creatorToken": {
+    "id": "27978",
+    "description": "ondrej.popelka@keboola.com"
+  },
+  "metrics": {
+    "inCompressed": False,
+    "inBytes": 0,
+    "inBytesUncompressed": 0,
+    "outCompressed": True,
+    "outBytes": 7168,
+    "outBytesUncompressed": 0
+  }
+}

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,62 @@
+import unittest
+
+from requests import HTTPError
+
+from kbcstorage.base import Endpoint
+
+
+class TestEndpoint(unittest.TestCase):
+    """
+    Test Endpoint functionality.
+    """
+    def setUp(self):
+        self.root = 'https://httpbin.org'
+        self.token = ''
+
+    def test_get(self):
+        """
+        Simple get works.
+        """
+        endpoint = Endpoint(self.root, 'get', self.token)
+        requested_url = endpoint.get(endpoint.base_url)['url']
+        assert requested_url == 'https://httpbin.org/get'
+
+    def test_get_404(self):
+        """
+        Get inexistent resource raises HTTPError.
+        """
+        endpoint = Endpoint(self.root, 'get', self.token)
+        with self.assertRaises(HTTPError):
+            endpoint.get('{}/not-a-url'.format(endpoint.base_url))
+
+    def test_post(self):
+        """
+        Simple post works.
+        """
+        endpoint = Endpoint(self.root, 'post', self.token)
+        requested_url = endpoint.post(endpoint.base_url)['url']
+        assert requested_url == 'https://httpbin.org/post'
+
+    def test_post_404(self):
+        """
+        Post to inexistent resource raises HTTPError.
+        """
+        endpoint = Endpoint(self.root, 'post', self.token)
+        with self.assertRaises(HTTPError):
+            endpoint.post('{}/not-a-url'.format(endpoint.base_url))
+
+    def test_delete(self):
+        """
+        Simple delete works.
+        """
+        endpoint = Endpoint(self.root, 'delete', self.token)
+        resp = endpoint.delete(endpoint.base_url)
+        assert resp is None
+
+    def test_delete_404(self):
+        """
+        Delete inexistent resource raises HTTPError.
+        """
+        endpoint = Endpoint(self.root, 'delete', self.token)
+        with self.assertRaises(HTTPError):
+            endpoint.delete('{}/not-a-url'.format(endpoint.base_url))

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -115,6 +115,4 @@ class TestBucketsWithMocks(unittest.TestCase):
         created_detail = self.buckets.create(name=name,
                                              description=description,
                                              backend=backend)
-        print(created_detail['id'])
-        print('in.{}'.format(name))
         assert created_detail['id'] == 'in.c-{}'.format(name)

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -1,30 +1,120 @@
-from kbcstorage.client import Client
 import os
 import unittest
+
 from requests import exceptions
+import responses
+
+from kbcstorage.buckets import Buckets
+from kbcstorage.client import Client
+
+from .bucket_responses import list_response, detail_response, create_response
 
 
 class TestBuckets(unittest.TestCase):
     def setUp(self):
-        self.client = Client(os.getenv('KBC_TEST_TOKEN'), os.getenv('KBC_TEST_API_URL'))
+        self.client = Client(os.getenv('KBC_TEST_API_URL'),
+                             os.getenv('KBC_TEST_TOKEN'))
         try:
-            self.client.drop_bucket('in.c-py-test', {'force': True})
+            self.client.buckets.delete('in.c-py-test', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
 
     def tearDown(self):
         try:
-            self.client.drop_bucket('in.c-py-test', {'force': True})
+            self.client.drop_bucket('in.c-py-test', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
 
     def test_create_bucket(self):
-        bucket_id = self.client.create_bucket('py-test', 'in', 'Test bucket')
-        self.assertTrue(self.client.bucket_exists(bucket_id))
+        bucket_id = self.client.buckets.create(name='py-test',
+                                               stage='in',
+                                               description='Test bucket')['id']
+        self.assertTrue(self.client.buckets.exists(bucket_id))
 
     def test_bucket_exists(self):
-        bucket_id = self.client.create_bucket('py-test', 'in', 'Test bucket')
-        self.assertTrue(self.client.bucket_exists(bucket_id))
-        self.assertFalse(self.client.bucket_exists('some-totally-non-existent-bucket'))
+        bucket_id = self.client.buckets.create(name='py-test',
+                                               stage='in',
+                                               description='Test bucket')['id']
+        self.assertTrue(self.client.buckets.exists(bucket_id))
+        self.assertFalse(
+            self.client.buckets.exists('some-totally-non-existent-bucket')
+        )
+
+
+class TestBucketsWithMocks(unittest.TestCase):
+    def setUp(self):
+            token = 'dummy_token'
+            base_url = 'https://connection.keboola.com/v2/storage/'
+            self.buckets = Buckets(base_url, token)
+
+    @responses.activate
+    def test_list(self):
+        """
+        Buckets mocks list correctly.
+        """
+        responses.add(
+            responses.Response(
+                method='GET',
+                url='https://connection.keboola.com/v2/storage/buckets',
+                json=list_response
+            )
+        )
+        buckets_list = self.buckets.list()
+        assert isinstance(buckets_list, list)
+
+    @responses.activate
+    def test_detail_by_id(self):
+        """
+        Buckets mocks detail by integer id correctly.
+        """
+        responses.add(
+            responses.Response(
+                method='GET',
+                url=('https://connection.keboola.com/v2/storage/buckets/'
+                     'in.c-ga'),
+                json=detail_response
+            )
+        )
+        bucket_id = 'in.c-ga'
+        bucket_detail = self.buckets.detail(bucket_id)
+        assert bucket_detail['id'] == 'in.c-ga'
+
+    @responses.activate
+    def test_delete(self):
+        """
+        Buckets mock deletes bucket by id.
+        """
+        responses.add(
+            responses.Response(
+                method='DELETE',
+                url='https://connection.keboola.com/v2/storage/buckets/1',
+                json={}
+            )
+        )
+        bucket_id = '1'
+        deleted_detail = self.buckets.delete(bucket_id)
+        assert deleted_detail is None
+
+    @responses.activate
+    def test_create(self):
+        """
+        Buckets mock creates new bucket.
+        """
+        responses.add(
+            responses.Response(
+                method='POST',
+                url='https://connection.keboola.com/v2/storage/buckets',
+                json=create_response
+            )
+        )
+        name = 'my-new-bucket'
+        description = 'Some Description'
+        backend = 'snowflake'
+        created_detail = self.buckets.create(name=name,
+                                             description=description,
+                                             backend=backend)
+        print(created_detail['id'])
+        print('in.{}'.format(name))
+        assert created_detail['id'] == 'in.c-{}'.format(name)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -80,7 +80,7 @@ class TestJobsEndpointWithMocks(unittest.TestCase):
         )
         job_id = 22077337
         job_completed = self.jobs.completed(job_id)
-        assert job_completed == True
+        assert job_completed is True
 
     @responses.activate
     def test_job_blocking(self):
@@ -93,7 +93,7 @@ class TestJobsEndpointWithMocks(unittest.TestCase):
                     method='GET',
                     url=('https://connection.keboola.com/v2/storage/jobs/'
                          '22077337'),
-                    json={'status':'processing'}
+                    json={'status': 'processing'}
                 )
             )
         responses.add(
@@ -130,7 +130,7 @@ class TestJobsEndpointWithMocks(unittest.TestCase):
         )
         job_id = 22077337
         success = self.jobs.block_for_success(job_id, d=0.000001)
-        assert success == True
+        assert success is True
 
     @responses.activate
     def test_success_blocking_if_error(self):
@@ -155,4 +155,4 @@ class TestJobsEndpointWithMocks(unittest.TestCase):
         )
         job_id = 22077337
         success = self.jobs.block_for_success(job_id, d=0.000001)
-        assert success == False
+        assert success is False

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,51 @@
+"""
+Test basic functionality of the Jobs endpoint
+"""
+import unittest
+
+import responses
+
+from kbcstorage.jobs import Jobs
+
+from .job_responses import list_response, detail_response
+
+
+class TestJobsEndpointWithMocks(unittest.TestCase):
+    """
+    Test the methods of a Jobs endpoint instance with mock HTTP responses
+    """
+    def setUp(self):
+        token = 'dummy_token'
+        base_url = 'https://connection.keboola.com/v2/storage/'
+        self.jobs = Jobs(base_url, token)
+
+    @responses.activate
+    def test_list(self):
+        """
+        Jobs mocks list correctly
+        """
+        responses.add(
+            responses.Response(
+                method='GET',
+                url='https://connection.keboola.com/v2/storage/jobs',
+                json=list_response
+            )
+        )
+        jobs_list = self.jobs.list()
+        assert isinstance(jobs_list, list)
+
+    @responses.activate
+    def test_detail_by_id(self):
+        """
+        Jobs Endpoint can mock detail by integer id
+        """
+        responses.add(
+            responses.Response(
+                method='GET',
+                url='https://connection.keboola.com/v2/storage/jobs/22077337',
+                json=detail_response
+            )
+        )
+        jobs_id = 22077337
+        jobs_detail = self.jobs.detail(jobs_id)
+        assert jobs_detail['id'] == 22077337

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -8,9 +8,9 @@ from requests import HTTPError
 
 from kbcstorage.workspaces import Workspaces
 
-from .workspace_responses import list_response, detail_response
-from .workspace_responses import load_tables_response, create_response
-from .workspace_responses import reset_password_response
+from .workspace_responses import (list_response, detail_response,
+                                  load_tables_response, create_response,
+                                  reset_password_response)
 
 
 class TestWorkspacesEndpointWithMocks(unittest.TestCase):
@@ -25,7 +25,7 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_list(self):
         """
-        Workspace list mocks correctly
+        Workspace mocks list correctly
         """
         responses.add(
             responses.Response(
@@ -40,7 +40,7 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_detail_by_integer_id(self):
         """
-        Workspace Endpoint can get mocked detail by integer id
+        Workspace Endpoint can mock detail by integer id
         """
         responses.add(
             responses.Response(
@@ -56,7 +56,7 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_detail_by_str_id(self):
         """
-        Workspace Endpoint can get mocked detail by integer id
+        Workspace Endpoint can get mocked detail by string id
         """
         responses.add(
             responses.Response(
@@ -72,7 +72,8 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_detail_inexsitent_workspace(self):
         """
-        Workspace Endpoint can get mocked detail by integer id
+        Workspace Endpoint raises HTTPError when mocking inexistent workspace
+        detail
         """
         msg = ('404 Client Error: Not Found for url: '
                'https://connection.keboola.com/v2/storage/workspaces/1')
@@ -106,7 +107,7 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_delete(self):
         """
-        Workspace endpoint deletes mock workspace by id
+        Workspace endpoint mock deletes workspace by id
         """
         responses.add(
             responses.Response(
@@ -141,7 +142,7 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_load_tables_to_workspace(self):
         """
-        Workspace endpoint deletes mock workspace by id
+        Workspace endpoint mock loads table
         """
         responses.add(
             responses.Response(
@@ -159,7 +160,7 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_load_inexistent_tables_to_workspace(self):
         """
-        Workspace endpoint deletes mock workspace by id
+        Workspace endpoint raises HTTPError when mock loading inexistent table
         """
         msg = ('404 Client Error: Not Found for url: '
                'https://connection.keboola.com/v2/storage/workspaces/78432/'
@@ -181,7 +182,7 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_reset_workspace_password(self):
         """
-        Reset password for workspace
+        Workspace endpoint mock resets password for workspace
         """
         responses.add(
             responses.Response(
@@ -198,7 +199,8 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
     @responses.activate
     def test_reset_password_for_inexistent_workspace(self):
         """
-        Reset password for inexistent workspace
+        Workspace endpoint raises HTTPError when mock resetting password for
+        inexistent workspace
         """
         msg = ('404 Client Error: Not Found for url: '
                'https://connection.keboola.com/v2/storage/workspaces/1/'

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -8,9 +8,9 @@ from requests import HTTPError
 
 from kbcstorage.workspaces import Workspaces
 
-from tests.workspace_responses import list_response, detail_response
-from tests.workspace_responses import load_tables_response, create_response
-from tests.workspace_responses import reset_password_response
+from .workspace_responses import list_response, detail_response
+from .workspace_responses import load_tables_response, create_response
+from .workspace_responses import reset_password_response
 
 
 class TestWorkspacesEndpointWithMocks(unittest.TestCase):
@@ -215,7 +215,3 @@ class TestWorkspacesEndpointWithMocks(unittest.TestCase):
         with self.assertRaises(HTTPError) as error_context:
             self.ws.reset_password(workspace_id)
         assert error_context.exception.args[0] == msg
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_workspaces_endpoint.py
+++ b/tests/test_workspaces_endpoint.py
@@ -1,0 +1,221 @@
+"""
+Asses basic functionality of the Workspace endpoint.
+"""
+import unittest
+
+import responses
+from requests import HTTPError
+
+from kbcstorage.workspaces import Workspaces
+
+from tests.workspace_responses import list_response, detail_response
+from tests.workspace_responses import load_tables_response, create_response
+from tests.workspace_responses import reset_password_response
+
+
+class TestWorkspacesEndpointWithMocks(unittest.TestCase):
+    """
+    Test the methods of a Workspaces endpoint instance with mock HTTP responses
+    """
+    def setUp(self):
+        token = 'dummy_token'
+        base_url = 'https://connection.keboola.com/v2/storage/'
+        self.ws = Workspaces(base_url, token)
+
+    @responses.activate
+    def test_list(self):
+        """
+        Workspace list mocks correctly
+        """
+        responses.add(
+            responses.Response(
+                method='GET',
+                url='https://connection.keboola.com/v2/storage/workspaces',
+                json=list_response
+            )
+        )
+        workspace_list = self.ws.list()
+        assert isinstance(workspace_list, list)
+
+    @responses.activate
+    def test_detail_by_integer_id(self):
+        """
+        Workspace Endpoint can get mocked detail by integer id
+        """
+        responses.add(
+            responses.Response(
+                method='GET',
+                url='https://connection.keboola.com/v2/storage/workspaces/1',
+                json=detail_response
+            )
+        )
+        workspace_id = 1
+        workspace_detail = self.ws.detail(workspace_id)
+        assert workspace_detail['id'] == 1
+
+    @responses.activate
+    def test_detail_by_str_id(self):
+        """
+        Workspace Endpoint can get mocked detail by integer id
+        """
+        responses.add(
+            responses.Response(
+                method='GET',
+                url='https://connection.keboola.com/v2/storage/workspaces/1',
+                json=detail_response
+            )
+        )
+        workspace_id = '1'
+        workspace_detail = self.ws.detail(workspace_id)
+        assert workspace_detail['id'] == 1
+
+    @responses.activate
+    def test_detail_inexsitent_workspace(self):
+        """
+        Workspace Endpoint can get mocked detail by integer id
+        """
+        msg = ('404 Client Error: Not Found for url: '
+               'https://connection.keboola.com/v2/storage/workspaces/1')
+        responses.add(
+            responses.Response(
+                method='GET',
+                url='https://connection.keboola.com/v2/storage/workspaces/1',
+                body=HTTPError(msg)
+            )
+        )
+        workspace_id = '1'
+        with self.assertRaises(HTTPError) as error_context:
+            self.ws.detail(workspace_id)
+        assert error_context.exception.args[0] == msg
+
+    @responses.activate
+    def test_create(self):
+        """
+        Workspace endpoint mock creates new workspace
+        """
+        responses.add(
+            responses.Response(
+                method='POST',
+                url='https://connection.keboola.com/v2/storage/workspaces',
+                json=create_response
+            )
+        )
+        created_detail = self.ws.create()
+        assert created_detail['connection']['password'] == 'abc'
+
+    @responses.activate
+    def test_delete(self):
+        """
+        Workspace endpoint deletes mock workspace by id
+        """
+        responses.add(
+            responses.Response(
+                method='DELETE',
+                url='https://connection.keboola.com/v2/storage/workspaces/1',
+                json=create_response
+            )
+        )
+        workspace_id = '1'
+        deleted_detail = self.ws.delete(workspace_id)
+        assert deleted_detail is None
+
+    @responses.activate
+    def test_delete_inexistent_workspace_raises_404(self):
+        """
+        Workspace endpoint raises 404 when mock deleting inexsitent workspace
+        """
+        msg = ('404 Client Error: Not Found for url: '
+               'https://connection.keboola.com/v2/storage/workspaces/1')
+        responses.add(
+            responses.Response(
+                method='DELETE',
+                url='https://connection.keboola.com/v2/storage/workspaces/1',
+                body=HTTPError(msg)
+            )
+        )
+        workspace_id = '1'
+        with self.assertRaises(HTTPError) as error_context:
+            self.ws.delete(workspace_id)
+        assert error_context.exception.args[0] == msg
+
+    @responses.activate
+    def test_load_tables_to_workspace(self):
+        """
+        Workspace endpoint deletes mock workspace by id
+        """
+        responses.add(
+            responses.Response(
+                method='POST',
+                url=('https://connection.keboola.com/v2/storage/workspaces/'
+                     '78432/load'),
+                json=load_tables_response
+            )
+        )
+        workspace_id = '78432'
+        mapping = {"in.c-application-testing.cashier-data": "my-table"}
+        loaded_detail = self.ws.load_tables(workspace_id, mapping)
+        assert loaded_detail['id'] == 22077337
+
+    @responses.activate
+    def test_load_inexistent_tables_to_workspace(self):
+        """
+        Workspace endpoint deletes mock workspace by id
+        """
+        msg = ('404 Client Error: Not Found for url: '
+               'https://connection.keboola.com/v2/storage/workspaces/78432/'
+               'load')
+        responses.add(
+            responses.Response(
+                method='POST',
+                url=('https://connection.keboola.com/v2/storage/workspaces/'
+                     '78432/load'),
+                body=HTTPError(msg)
+            )
+        )
+        workspace_id = '78432'
+        mapping = {"in.c-table.does_not_exist": "my-table"}
+        with self.assertRaises(HTTPError) as error_context:
+            self.ws.load_tables(workspace_id, mapping)
+        assert error_context.exception.args[0] == msg
+
+    @responses.activate
+    def test_reset_workspace_password(self):
+        """
+        Reset password for workspace
+        """
+        responses.add(
+            responses.Response(
+                method='POST',
+                url=('https://connection.keboola.com/v2/storage/workspaces/'
+                     '1/password'),
+                json=reset_password_response
+            )
+        )
+        workspace_id = '1'
+        reset_detail = self.ws.reset_password(workspace_id)
+        assert reset_detail['password'] == 'top_secret_password'
+
+    @responses.activate
+    def test_reset_password_for_inexistent_workspace(self):
+        """
+        Reset password for inexistent workspace
+        """
+        msg = ('404 Client Error: Not Found for url: '
+               'https://connection.keboola.com/v2/storage/workspaces/1/'
+               'password')
+        responses.add(
+            responses.Response(
+                method='POST',
+                url=('https://connection.keboola.com/v2/storage/workspaces/'
+                     '1/password'),
+                body=HTTPError(msg)
+            )
+        )
+        workspace_id = '1'
+        with self.assertRaises(HTTPError) as error_context:
+            self.ws.reset_password(workspace_id)
+        assert error_context.exception.args[0] == msg
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/workspace_responses.py
+++ b/tests/workspace_responses.py
@@ -1,0 +1,114 @@
+list_response = [
+    {
+        "id": 234,
+        "name": "boring_wozniak",
+        "component": "wr-db",
+        "configurationId": "aws-1",
+        "created": "2016-05-17T11:11:20+0200",
+        "connection": {
+            "backend": "snowflake",
+            "host": "keboola.snowflakecomputing.com",
+            "database": "keboola_123",
+            "schema": "boring_wozniak",
+            "warehouse": "SAPI_PROD",
+            "user": "xzy"
+        },
+        "creatorToken": {
+          "id": 234,
+          "description": "martin@keboola.com"
+        },
+        "creatorUser": {
+            "id": 234,
+            "name": "Martin"
+        }
+    }
+]
+
+detail_response = {
+    "id": 1,
+    "name": "boring_wozniak",
+    "component": "wr-db",
+    "configurationId": "aws-1",
+    "created": "2016-05-17T11:11:20+0200",
+    "connection": {
+        "backend": "snowflake",
+        "host": "keboola.snowflakecomputing.com",
+        "database": "keboola_123",
+        "schema": "boring_wozniak",
+        "warehouse": "SAPI_PROD",
+        "user": "xzy"
+    },
+    "creatorToken": {
+        "id": 234,
+        "description": "martin@keboola.com"
+    },
+    "creatorUser": {
+        "id": 234,
+        "name": "Martin"
+    }
+}
+
+create_response = {
+    "id": 234,
+    "name": "boring_wozniak",
+    "component": "wr-db",
+    "configurationId": "aws-1",
+    "created": "2016-05-17T11:11:20+0200",
+    "connection": {
+        "backend": "snowflake",
+        "host": "keboola.snowflakecomputing.com",
+        "database": "keboola_123",
+        "schema": "boring_wozniak",
+        "warehouse": "SAPI_PROD",
+        "user": "xzy",
+        "password": "abc"
+    },
+    "creatorToken": {
+        "id": 234,
+        "description": "martin@keboola.com"
+    },
+    "creatorUser": {
+        "id": 234,
+        "name": "Martin"
+    }
+}
+
+load_tables_response = {
+    "id": 22077337,
+    "status": "waiting",
+    "url": "https://connection.keboola.com/v2/storage/jobs/22077337",
+    "tableId": None,
+    "operationName": "workspaceLoad",
+    "operationParams": {
+        "workspaceId": "78423",
+        "preserve": False,
+        "input": [
+            {
+                "source": "in.c-application-testing.cashier-data",
+                "destination": "my-table"
+            }
+        ],
+        "queue": "main_fast"
+    },
+    "createdTime": "2017-02-13T16:41:18+0100",
+    "startTime": None,
+    "endTime": None,
+    "runId": None,
+    "results": None,
+    "creatorToken": {
+        "id": "27978",
+        "description": "ondrej.popelka@keboola.com"
+    },
+    "metrics": {
+        "inCompressed": False,
+        "inBytes": 0,
+        "inBytesUncompressed": 0,
+        "outCompressed": False,
+        "outBytes": 0,
+        "outBytesUncompressed": 0
+    }
+}
+
+reset_password_response = {
+    "password": "top_secret_password",
+}


### PR DESCRIPTION
I've been working on this throughout the week and think it could probably do with more work & reviewing before merging: I'd definitely appreciate feedback.

This PR is mostly a proof of concept of the architecture laid out by @pocin in #6: I've tried to stay close to the API and so you could call it quite a thin client?

I've also had a play with some tests. I used the very nice [responses](https://github.com/getsentry/responses) library to mock requests, and that way we don't need real tokens or even an Internet connection to test the client. In the tests you define what the API response *should be* and assert that the client isn't making any mistakes before or after calling requests. I think it might still be useful to have some real API calls to make sure everything is working sensibly, but I don't think I have access to the test environment.

I also modified `setup.py` a bit. Essentially, previously upon install a package called `tests` was also being installed. Now, that should no longer be the case. If you want to run the tests, you should clone the directory and run them. There are several options for running tests:

After `pip install responses`, do

```bash
cd path/to/sapi-python-client/ && python -m unittest discover
```

or

```bash
python -m discover -s path/to/sapi-python-client/
```

or 


```bash
pytest path/to/sapi-python-client/tests/
```

or

```bash
green path/to/sapi-python-client/tests/
```

etc.

Alternatively, without needing to even install the package:

```bash
git clone git@github.com:Ogaday/sapi-python-client.git && cd sapi-python-client && python setup.py test
```

Which takes care of all dependencies.