### PR TITLE
Refactor endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-test:
-	python -m 'pytest'

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -39,14 +39,20 @@ class Endpoint:
         self.token = token
         self._auth_header = {'X-StorageApi-Token': self.token}
 
-    def _get(self, *args, **kwargs):
+    def _get(self, url, params=None, as_json=True, **kwargs):
         """
         Construct a requests GET call with args and kwargs and process the
         results.
 
+
         Args:
-            *args: Positional arguments to pass to the get request.
-            **kwargs: Key word arguments to pass to the get request.
+            url (str): requested url
+            params (dict): additional url params to be passed to the underlying
+                requests.get
+            as_json (bool): whether to return json decoded response or raw
+                response object. It's important, because for example the
+                Tables.preview() returns a non-json response
+            **kwargs: Key word arguments to pass to the get requests.get
 
         Returns:
             body: Response body parsed from json.
@@ -57,14 +63,14 @@ class Endpoint:
         headers = kwargs.pop('headers', {})
         headers.update(self._auth_header)
 
-        r = requests.get(headers=headers, *args, **kwargs)
+        r = requests.get(url, params, headers=headers, **kwargs)
         try:
             r.raise_for_status()
         except requests.HTTPError:
             # Handle different error codes
             raise
         else:
-            return r.json()
+            return r.json() if as_json else r
 
     def _post(self, *args, **kwargs):
         """

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -37,6 +37,7 @@ class Endpoint:
         self.base_url = '{}/v2/storage/{}'.format(root_url.strip('/'),
                                                   path_component.strip('/'))
         self.token = token
+        self._auth_header = {'X-StorageApi-Token': self.token}
 
     def _get(self, *args, **kwargs):
         """
@@ -53,7 +54,10 @@ class Endpoint:
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        r = requests.get(*args, **kwargs)
+        headers = kwargs.pop('headers', {})
+        headers.update(self._auth_header)
+
+        r = requests.get(headers=headers, *args, **kwargs)
         try:
             r.raise_for_status()
         except requests.HTTPError:
@@ -77,7 +81,9 @@ class Endpoint:
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        r = requests.post(*args, **kwargs)
+        headers = kwargs.pop('headers', {})
+        headers.update(self._auth_header)
+        r = requests.post(headers=headers, *args, **kwargs)
         try:
             r.raise_for_status()
         except requests.HTTPError:
@@ -101,7 +107,9 @@ class Endpoint:
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        r = requests.delete(*args, **kwargs)
+        headers = kwargs.pop('headers', {})
+        headers.update(self._auth_header)
+        r = requests.delete(headers=headers, *args, **kwargs)
         try:
             r.raise_for_status()
         except requests.HTTPError:

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -38,7 +38,7 @@ class Endpoint:
                                                   path_component.strip('/'))
         self.token = token
 
-    def get(self, *args, **kwargs):
+    def _get(self, *args, **kwargs):
         """
         Construct a requests GET call with args and kwargs and process the
         results.
@@ -62,7 +62,7 @@ class Endpoint:
         else:
             return r.json()
 
-    def post(self, *args, **kwargs):
+    def _post(self, *args, **kwargs):
         """
         Construct a requests POST call with args and kwargs and process the
         results.
@@ -86,7 +86,7 @@ class Endpoint:
         else:
             return r.json()
 
-    def delete(self, *args, **kwargs):
+    def _delete(self, *args, **kwargs):
         """
         Construct a requests DELETE call with args and kwargs and process the
         result

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -39,7 +39,7 @@ class Endpoint:
         self.token = token
         self._auth_header = {'X-StorageApi-Token': self.token}
 
-    def _get(self, url, params=None, as_json=True, **kwargs):
+    def _get(self, url, params=None, **kwargs):
         """
         Construct a requests GET call with args and kwargs and process the
         results.
@@ -49,13 +49,10 @@ class Endpoint:
             url (str): requested url
             params (dict): additional url params to be passed to the underlying
                 requests.get
-            as_json (bool): whether to return json decoded response or raw
-                response object. It's important, because for example the
-                Tables.preview() returns a non-json response
             **kwargs: Key word arguments to pass to the get requests.get
 
         Returns:
-            body: Response body parsed from json.
+            r (requests.Response): object
 
         Raises:
             requests.HTTPError: If the API request fails.
@@ -70,7 +67,7 @@ class Endpoint:
             # Handle different error codes
             raise
         else:
-            return r.json() if as_json else r
+            return r
 
     def _post(self, *args, **kwargs):
         """
@@ -96,7 +93,7 @@ class Endpoint:
             # Handle different error codes
             raise
         else:
-            return r.json()
+            return r
 
     def _delete(self, *args, **kwargs):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -34,7 +34,7 @@ class Buckets(Endpoint):
             requests.HTTPError: If the API request fails.
         """
 
-        return self._get(self.base_url)
+        return self._get(self.base_url).json()
 
     def list_tables(self, bucket_id, include=None):
         """
@@ -55,7 +55,7 @@ class Buckets(Endpoint):
         params = {}
         if include is not None and isinstance(include, list):
             params['include'] = ','.join(include)
-        return self._get(url, headers=headers, params=params)
+        return self._get(url, headers=headers, params=params).json()
 
     def detail(self, bucket_id):
         """
@@ -69,7 +69,7 @@ class Buckets(Endpoint):
         """
         url = '{}/{}'.format(self.base_url, bucket_id)
 
-        return self._get(url)
+        return self._get(url).json()
 
     def create(self, name, stage='in', description='', backend=None):
         """
@@ -98,7 +98,7 @@ class Buckets(Endpoint):
             'backend': backend
         }
 
-        return self._post(self.base_url, data=body)
+        return self._post(self.base_url, data=body).json()
 
     def delete(self, bucket_id, force=False):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -35,7 +35,7 @@ class Buckets(Endpoint):
         """
         headers = {'X-StorageApi-Token': self.token}
 
-        return self.get(self.base_url, headers=headers)
+        return self._get(self.base_url, headers=headers)
 
     def list_tables(self, bucket_id, include=None):
         """
@@ -71,7 +71,7 @@ class Buckets(Endpoint):
         url = '{}/{}'.format(self.base_url, bucket_id)
         headers = {'X-StorageApi-Token': self.token}
 
-        return self.get(url, headers=headers)
+        return self._get(url, headers=headers)
 
     def create(self, name, stage='in', description='', backend=None):
         """
@@ -104,7 +104,7 @@ class Buckets(Endpoint):
             'backend': backend
         }
 
-        return self.post(self.base_url, headers=headers, data=body)
+        return self._post(self.base_url, headers=headers, data=body)
 
     def delete(self, bucket_id, force=False):
         """
@@ -124,7 +124,7 @@ class Buckets(Endpoint):
         url = '{}/{}'.format(self.base_url, bucket_id)
         headers = {'X-StorageApi-Token': self.token}
         params = {'force': force}
-        super().delete(url, headers=headers, params=params)
+        self._delete(url, headers=headers, params=params)
 
     def link(self, *args, **kwargs):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -56,7 +56,7 @@ class Buckets(Endpoint):
         params = {}
         if include is not None and isinstance(include, list):
             params['include'] = ','.join(include)
-        return self.get(url, headers=headers, params=params)
+        return self._get(url, headers=headers, params=params)
 
     def detail(self, bucket_id):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -33,9 +33,8 @@ class Buckets(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
 
-        return self._get(self.base_url, headers=headers)
+        return self._get(self.base_url)
 
     def list_tables(self, bucket_id, include=None):
         """
@@ -69,9 +68,8 @@ class Buckets(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, bucket_id)
-        headers = {'X-StorageApi-Token': self.token}
 
-        return self._get(url, headers=headers)
+        return self._get(url)
 
     def create(self, name, stage='in', description='', backend=None):
         """
@@ -92,10 +90,6 @@ class Buckets(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         # Separating create and link into two distinct functions...
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         # Need to check args...
         body = {
             'name': name,
@@ -104,7 +98,7 @@ class Buckets(Endpoint):
             'backend': backend
         }
 
-        return self._post(self.base_url, headers=headers, data=body)
+        return self._post(self.base_url, data=body)
 
     def delete(self, bucket_id, force=False):
         """
@@ -122,9 +116,8 @@ class Buckets(Endpoint):
         # How does the API handle it when force == False and the bucket is non-
         # empty?
         url = '{}/{}'.format(self.base_url, bucket_id)
-        headers = {'X-StorageApi-Token': self.token}
         params = {'force': force}
-        self._delete(url, headers=headers, params=params)
+        self._delete(url, params=params)
 
     def link(self, *args, **kwargs):
         """

--- a/kbcstorage/files.py
+++ b/kbcstorage/files.py
@@ -43,7 +43,7 @@ class Files(Endpoint):
         params = {}
         if federation_token:
             params['federationToken'] = 'true'
-        return self._get(url, params=params)
+        return self._get(url, params=params).json()
 
     def upload_file(self, file_path, tags=None, is_public=False,
                     is_permanent=False, is_encrypted=True,
@@ -135,7 +135,7 @@ class Files(Endpoint):
             body['sizeBytes'] = size_bytes
         if federation_token is not None:
             body['federationToken'] = int(federation_token)
-        return self._post(url, data=body)
+        return self._post(url, data=body).json()
 
     def delete(self, file_id):
         """
@@ -179,7 +179,7 @@ class Files(Endpoint):
             params['sinceId'] = since_id
         if max_id is not None:
             params['maxId'] = max_id
-        return self._get(self.base_url, params=params)
+        return self._get(self.base_url, params=params).json()
 
     def download(self, file_id, local_path):
         if not os.path.exists(local_path):

--- a/kbcstorage/files.py
+++ b/kbcstorage/files.py
@@ -44,7 +44,7 @@ class Files(Endpoint):
         params = {}
         if federation_token:
             params['federationToken'] = 'true'
-        return self.get(url, headers=headers, params=params)
+        return self._get(url, headers=headers, params=params)
 
     def upload_file(self, file_path, tags=None, is_public=False,
                     is_permanent=False, is_encrypted=True,
@@ -140,7 +140,7 @@ class Files(Endpoint):
             body['sizeBytes'] = size_bytes
         if federation_token is not None:
             body['federationToken'] = int(federation_token)
-        return self.post(url, headers=headers, data=body)
+        return self._post(url, headers=headers, data=body)
 
     def delete(self, file_id):
         """
@@ -151,7 +151,7 @@ class Files(Endpoint):
         """
         url = '{}/{}'.format(self.base_url, file_id)
         headers = {'X-StorageApi-Token': self.token}
-        super().delete(url, headers=headers)
+        self._delete(url, headers=headers)
 
     def list(self, limit=100, offset=0, tags=None, q=None, run_id=None,
              since_id=None, max_id=None):
@@ -186,7 +186,7 @@ class Files(Endpoint):
             params['sinceId'] = since_id
         if max_id is not None:
             params['maxId'] = max_id
-        return super().get(self.base_url, headers=headers, params=params)
+        return self._get(self.base_url, headers=headers, params=params)
 
     def download(self, file_id, local_path):
         if not os.path.exists(local_path):

--- a/kbcstorage/files.py
+++ b/kbcstorage/files.py
@@ -40,11 +40,10 @@ class Files(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, file_id)
-        headers = {'X-StorageApi-Token': self.token}
         params = {}
         if federation_token:
             params['federationToken'] = 'true'
-        return self._get(url, headers=headers, params=params)
+        return self._get(url, params=params)
 
     def upload_file(self, file_path, tags=None, is_public=False,
                     is_permanent=False, is_encrypted=True,
@@ -122,10 +121,6 @@ class Files(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, 'prepare')
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'isPublic': int(is_public),
             'isPermanent': int(is_permanent),
@@ -140,7 +135,7 @@ class Files(Endpoint):
             body['sizeBytes'] = size_bytes
         if federation_token is not None:
             body['federationToken'] = int(federation_token)
-        return self._post(url, headers=headers, data=body)
+        return self._post(url, data=body)
 
     def delete(self, file_id):
         """
@@ -150,8 +145,7 @@ class Files(Endpoint):
             file_id (str): The id of the file to be deleted.
         """
         url = '{}/{}'.format(self.base_url, file_id)
-        headers = {'X-StorageApi-Token': self.token}
-        self._delete(url, headers=headers)
+        self._delete(url)
 
     def list(self, limit=100, offset=0, tags=None, q=None, run_id=None,
              since_id=None, max_id=None):
@@ -173,7 +167,6 @@ class Files(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         params = {
             'limit': int(limit),
             'offset': int(offset)
@@ -186,7 +179,7 @@ class Files(Endpoint):
             params['sinceId'] = since_id
         if max_id is not None:
             params['maxId'] = max_id
-        return self._get(self.base_url, headers=headers, params=params)
+        return self._get(self.base_url, params=params)
 
     def download(self, file_id, local_path):
         if not os.path.exists(local_path):

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -53,9 +53,7 @@ class Jobs(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
-
-        return self._get(self.base_url, headers=headers)
+        return self._get(self.base_url)
 
     def detail(self, job_id):
         """
@@ -67,10 +65,9 @@ class Jobs(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         url = '{}/{}'.format(self.base_url, job_id)
 
-        return self._get(url, headers=headers)
+        return self._get(url)
 
     def status(self, job_id):
         """

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -55,7 +55,7 @@ class Jobs(Endpoint):
         """
         headers = {'X-StorageApi-Token': self.token}
 
-        return self.get(self.base_url, headers=headers)
+        return self._get(self.base_url, headers=headers)
 
     def detail(self, job_id):
         """
@@ -70,7 +70,7 @@ class Jobs(Endpoint):
         headers = {'X-StorageApi-Token': self.token}
         url = '{}/{}'.format(self.base_url, job_id)
 
-        return self.get(url, headers=headers)
+        return self._get(url, headers=headers)
 
     def status(self, job_id):
         """

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -53,7 +53,7 @@ class Jobs(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        return self._get(self.base_url)
+        return self._get(self.base_url).json()
 
     def detail(self, job_id):
         """
@@ -67,7 +67,7 @@ class Jobs(Endpoint):
         """
         url = '{}/{}'.format(self.base_url, job_id)
 
-        return self._get(url)
+        return self._get(url).json()
 
     def status(self, job_id):
         """

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -377,7 +377,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/data-preview'.format(self.base_url, table_id)
-        r = requests.get(url=url, params=params)
+        r = self._get(url=url, params=params)
         try:
             r.raise_for_status()
         except requests.HTTPError:

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -45,7 +45,7 @@ class Tables(Endpoint):
 
         url = '{}/tables'.format(self.base_url)
         params = {'include': ','.join(include)}
-        return self._get(url, params=params)
+        return self._get(url, params=params).json()
 
     def list_bucket(self, bucket_id, include=None):
         """
@@ -63,7 +63,7 @@ class Tables(Endpoint):
 
         url = '{}/{}/tables'.format(self.base_url, bucket_id)
         params = {'include': ','.join(include)}
-        return self._get(url, params=params)
+        return self._get(url, params=params).json()
 
     def detail(self, table_id):
         """
@@ -78,7 +78,7 @@ class Tables(Endpoint):
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
-        return self._get(url)
+        return self._get(url).json()
 
     def delete(self, table_id):
         """
@@ -175,7 +175,7 @@ class Tables(Endpoint):
         # todo solve this better
         url = '{}/v2/storage/buckets/{}/tables-async'.format(self.root_url,
                                                              bucket_id)
-        return self._post(url, data=body)
+        return self._post(url, data=body).json()
 
     @staticmethod
     def validate_data_source(data_url, data_file_id, snapshot_id,
@@ -313,7 +313,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             body['primaryKey[]'] = columns
         url = '{}/{}/import-async'.format(self.base_url, table_id)
-        return self._post(url, data=body)
+        return self._post(url, data=body).json()
 
     @staticmethod
     def validate_filter(where_column, where_operator, where_values):
@@ -377,13 +377,8 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/data-preview'.format(self.base_url, table_id)
-        r = self._get(url=url, params=params, as_json=False)
-        try:
-            r.raise_for_status()
-        except requests.HTTPError:
-            raise
-        else:
-            return r.content.decode('utf-8')
+        r = self._get(url=url, params=params)
+        return r.content.decode('utf-8')
 
     def export_to_file(self, table_id, path_name, limit=None,
                        file_format='rfc', changed_since=None,
@@ -541,4 +536,4 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/export-async'.format(self.base_url, table_id)
-        return self._post(url, data=params)
+        return self._post(url, data=params).json()

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -46,7 +46,26 @@ class Tables(Endpoint):
 
         url = '{}/tables'.format(self.base_url)
         params = {'include': ','.join(include)}
-        return self.get(url, headers=headers, params=params)
+        return self._get(url, headers=headers, params=params)
+
+    def list_bucket(self, bucket_id, include=None):
+        """
+        List all tables in a bucket.
+
+        Args:
+            bucket_id (str): Id of the bucket
+            include (list): Properties to list (attributes, columns)
+        Returns:
+            response_body: The parsed json from the HTTP response.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        headers = {'X-StorageApi-Token': self.token}
+
+        url = '{}/{}/tables'.format(self.base_url, bucket_id)
+        params = {'include': ','.join(include)}
+        return self._get(url, headers=headers, params=params)
 
     def detail(self, table_id):
         """
@@ -62,7 +81,7 @@ class Tables(Endpoint):
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
         headers = {'X-StorageApi-Token': self.token}
-        return self.get(url, headers=headers)
+        return self._get(url, headers=headers)
 
     def delete(self, table_id):
         """
@@ -75,7 +94,7 @@ class Tables(Endpoint):
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
         headers = {'X-StorageApi-Token': self.token}
-        super().delete(url, headers=headers)
+        self._delete(url, headers=headers)
 
     def create(self, bucket_id, name, file_path, delimiter=',', enclosure='"',
                escaped_by='', primary_key=None):
@@ -164,7 +183,7 @@ class Tables(Endpoint):
         # todo solve this better
         url = '{}/v2/storage/buckets/{}/tables-async'.format(self.root_url,
                                                              bucket_id)
-        return self.post(url, headers=headers, data=body)
+        return self._post(url, headers=headers, data=body)
 
     @staticmethod
     def validate_data_source(data_url, data_file_id, snapshot_id,
@@ -306,7 +325,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             body['primaryKey[]'] = columns
         url = '{}/{}/import-async'.format(self.base_url, table_id)
-        return self.post(url, headers=headers, data=body)
+        return self._post(url, headers=headers, data=body)
 
     @staticmethod
     def validate_filter(where_column, where_operator, where_values):
@@ -536,4 +555,4 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/export-async'.format(self.base_url, table_id)
-        return self.post(url, headers=headers, data=params)
+        return self._post(url, headers=headers, data=params)

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -42,11 +42,10 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
 
         url = '{}/tables'.format(self.base_url)
         params = {'include': ','.join(include)}
-        return self._get(url, headers=headers, params=params)
+        return self._get(url, params=params)
 
     def list_bucket(self, bucket_id, include=None):
         """
@@ -61,11 +60,10 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
 
         url = '{}/{}/tables'.format(self.base_url, bucket_id)
         params = {'include': ','.join(include)}
-        return self._get(url, headers=headers, params=params)
+        return self._get(url, params=params)
 
     def detail(self, table_id):
         """
@@ -80,8 +78,7 @@ class Tables(Endpoint):
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
-        headers = {'X-StorageApi-Token': self.token}
-        return self._get(url, headers=headers)
+        return self._get(url)
 
     def delete(self, table_id):
         """
@@ -93,8 +90,7 @@ class Tables(Endpoint):
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
-        headers = {'X-StorageApi-Token': self.token}
-        self._delete(url, headers=headers)
+        self._delete(url)
 
     def create(self, bucket_id, name, file_path, delimiter=',', enclosure='"',
                escaped_by='', primary_key=None):
@@ -162,10 +158,6 @@ class Tables(Endpoint):
             raise ValueError("Invalid bucket_id '{}'.".format(bucket_id))
         if not isinstance(name, str) or name == '':
             raise ValueError("Invalid name_id '{}'.".format(name))
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'name': name,
             'delimiter': delimiter,
@@ -183,7 +175,7 @@ class Tables(Endpoint):
         # todo solve this better
         url = '{}/v2/storage/buckets/{}/tables-async'.format(self.root_url,
                                                              bucket_id)
-        return self._post(url, headers=headers, data=body)
+        return self._post(url, data=body)
 
     @staticmethod
     def validate_data_source(data_url, data_file_id, snapshot_id,
@@ -305,10 +297,6 @@ class Tables(Endpoint):
         """
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid file_id '{}'.".format(table_id))
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'delimiter': delimiter,
             'enclosure': enclosure,
@@ -325,7 +313,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             body['primaryKey[]'] = columns
         url = '{}/{}/import-async'.format(self.base_url, table_id)
-        return self._post(url, headers=headers, data=body)
+        return self._post(url, data=body)
 
     @staticmethod
     def validate_filter(where_column, where_operator, where_values):
@@ -371,7 +359,6 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         params = {}
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
@@ -390,7 +377,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/data-preview'.format(self.base_url, table_id)
-        r = requests.get(url=url, headers=headers, params=params)
+        r = requests.get(url=url, params=params)
         try:
             r.raise_for_status()
         except requests.HTTPError:
@@ -530,7 +517,6 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         params = {
             'gzip': int(is_gzip)
         }
@@ -555,4 +541,4 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/export-async'.format(self.base_url, table_id)
-        return self._post(url, headers=headers, data=params)
+        return self._post(url, data=params)

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -377,7 +377,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/data-preview'.format(self.base_url, table_id)
-        r = self._get(url=url, params=params)
+        r = self._get(url=url, params=params, as_json=False)
         try:
             r.raise_for_status()
         except requests.HTTPError:

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -52,8 +52,7 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
-        return self._get(self.base_url, headers=headers)
+        return self._get(self.base_url)
 
     def detail(self, workspace_id):
         """
@@ -68,9 +67,8 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         url = '{}/{}'.format(self.base_url, workspace_id)
-        return self._get(url, headers=headers)
+        return self._get(url)
 
     def create(self, backend=None, timeout=None):
         """
@@ -85,16 +83,12 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'backend': backend,
             'statementTimeoutSeconds': timeout
         }
 
-        return self._post(self.base_url, data=body, headers=headers)
+        return self._post(self.base_url, data=body)
 
     def delete(self, workspace_id):
         """
@@ -108,13 +102,9 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         url = '{}/{}'.format(self.base_url, workspace_id)
 
-        self._delete(url, headers=headers)
+        self._delete(url)
 
     def reset_password(self, workspace_id):
         """
@@ -127,12 +117,8 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         url = '{}/{}/password'.format(self.base_url, workspace_id)
-        return self._post(url, headers=headers)
+        return self._post(url)
 
     def load_tables(self, workspace_id, table_mapping, preserve=None):
         """
@@ -152,12 +138,8 @@ class Workspaces(Endpoint):
         Todo:
             * Column data types.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = _make_body(table_mapping)
         body['preserve'] = preserve
         url = '{}/{}/load'.format(self.base_url, workspace_id)
 
-        return self._post(url, data=body, headers=headers)
+        return self._post(url, data=body)

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -52,7 +52,7 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        return self._get(self.base_url)
+        return self._get(self.base_url).json()
 
     def detail(self, workspace_id):
         """
@@ -68,7 +68,7 @@ class Workspaces(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, workspace_id)
-        return self._get(url)
+        return self._get(url).json()
 
     def create(self, backend=None, timeout=None):
         """
@@ -88,7 +88,7 @@ class Workspaces(Endpoint):
             'statementTimeoutSeconds': timeout
         }
 
-        return self._post(self.base_url, data=body)
+        return self._post(self.base_url, data=body).json()
 
     def delete(self, workspace_id):
         """
@@ -118,7 +118,7 @@ class Workspaces(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}/password'.format(self.base_url, workspace_id)
-        return self._post(url)
+        return self._post(url).json()
 
     def load_tables(self, workspace_id, table_mapping, preserve=None):
         """
@@ -142,4 +142,4 @@ class Workspaces(Endpoint):
         body['preserve'] = preserve
         url = '{}/{}/load'.format(self.base_url, workspace_id)
 
-        return self._post(url, data=body)
+        return self._post(url, data=body).json()

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -53,7 +53,7 @@ class Workspaces(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         headers = {'X-StorageApi-Token': self.token}
-        return self.get(self.base_url, headers=headers)
+        return self._get(self.base_url, headers=headers)
 
     def detail(self, workspace_id):
         """
@@ -70,7 +70,7 @@ class Workspaces(Endpoint):
         """
         headers = {'X-StorageApi-Token': self.token}
         url = '{}/{}'.format(self.base_url, workspace_id)
-        return self.get(url, headers=headers)
+        return self._get(url, headers=headers)
 
     def create(self, backend=None, timeout=None):
         """
@@ -94,7 +94,7 @@ class Workspaces(Endpoint):
             'statementTimeoutSeconds': timeout
         }
 
-        return self.post(self.base_url, data=body, headers=headers)
+        return self._post(self.base_url, data=body, headers=headers)
 
     def delete(self, workspace_id):
         """
@@ -114,8 +114,7 @@ class Workspaces(Endpoint):
         }
         url = '{}/{}'.format(self.base_url, workspace_id)
 
-        # This shadows the superclass...
-        return super().delete(url, headers=headers)
+        self._delete(url, headers=headers)
 
     def reset_password(self, workspace_id):
         """
@@ -133,7 +132,7 @@ class Workspaces(Endpoint):
             'Content-Type': 'application/x-www-form-urlencoded'
         }
         url = '{}/{}/password'.format(self.base_url, workspace_id)
-        return self.post(url, headers=headers)
+        return self._post(url, headers=headers)
 
     def load_tables(self, workspace_id, table_mapping, preserve=None):
         """
@@ -161,4 +160,4 @@ class Workspaces(Endpoint):
         body['preserve'] = preserve
         url = '{}/{}/load'.format(self.base_url, workspace_id)
 
-        return self.post(url, data=body, headers=headers)
+        return self._post(url, data=body, headers=headers)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -51,3 +51,14 @@ class TestEndpoint(unittest.TestCase):
         endpoint = Endpoint(self.root, 'delete', self.token)
         with self.assertRaises(HTTPError):
             endpoint._delete('{}/not-a-url'.format(endpoint.base_url))
+
+    def test_custom_headers(self):
+        """
+        Passing custom headers to Endpoint._get()
+        """
+        endpoint = Endpoint(self.root, '', self.token)
+        resp = endpoint._get(self.root, headers={'x-foo':'bar'})
+        request_headers = resp.request.headers
+        self.assertIn('x-foo', request_headers)
+        self.assertIn('X-StorageApi-Token', request_headers)
+        self.assertEqual('bar', request_headers['x-foo'])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -26,7 +26,7 @@ class TestEndpoint(unittest.TestCase):
                          '/v2/storage/not-a-url',
                          endpoint.base_url)
         with self.assertRaises(HTTPError):
-            endpoint.get(endpoint.base_url)
+            endpoint._get(endpoint.base_url)
 
     def test_get_404_2(self):
         endpoint = Endpoint(self.root, '', self.token)
@@ -34,7 +34,7 @@ class TestEndpoint(unittest.TestCase):
                          '/v2/storage/',
                          endpoint.base_url)
         with self.assertRaises(HTTPError):
-            endpoint.get('{}/not-a-url'.format(endpoint.base_url))
+            endpoint._get('{}/not-a-url'.format(endpoint.base_url))
 
     def test_post_404(self):
         """
@@ -42,7 +42,7 @@ class TestEndpoint(unittest.TestCase):
         """
         endpoint = Endpoint(self.root, '', self.token)
         with self.assertRaises(HTTPError):
-            endpoint.post('{}/not-a-url'.format(endpoint.base_url))
+            endpoint._post('{}/not-a-url'.format(endpoint.base_url))
 
     def test_delete_404(self):
         """
@@ -50,4 +50,4 @@ class TestEndpoint(unittest.TestCase):
         """
         endpoint = Endpoint(self.root, 'delete', self.token)
         with self.assertRaises(HTTPError):
-            endpoint.delete('{}/not-a-url'.format(endpoint.base_url))
+            endpoint._delete('{}/not-a-url'.format(endpoint.base_url))


### PR DESCRIPTION
1. I refactored the base `Endpoint` `get`, `put`, `delete` methods to "private" (`_get`, `_put`, `_post`)
This is because there were some naming collisions in `Buckets.delete()` and the `super()` was being abused.
---

2. Next I refactored the authentication header handling to the base `Endpoint` class. This new style still allows passing of custom headers (exactly the same way as you'd expect).

```python
class Tables(Endpoint):
    ...
    def list(self):
        custom_headers = {'X-custom-header1': "12345"}
        self._get(urljoin(self.base_url, 'list'), headers=custom_headers)
```
In the example above, the request headers will contain both `X-custom-header1` and `X-storage-token`. In case of `POST` requests, the `content-type: application/x-www-form-urlencoded` is added automatically (more on this in #25 soon)

---

3. Lastly (and most importantly) I introduced a `as_json` argument to `Endpoint._get` method.
This is because the `Tables.preview()` endpoint doesn't return json. The default behavior is still to return json, though.

Now I am thinking we might try something like this (which I favor the least):
```python
#in the Endpoint class
class Endpoint:
    def _get(self, url, params, **kwargs):
        r = requests.get(url, params, **kwargs)
        try:
            r.raise_for_status()
        except requests.HTTPError:
            # Handle different error codes
            raise
        else:
            try:
                return r.json()
            except JSONDecodeError:
                return r.content.decode('utf-8')
```
Or maybe we can always return the `Response` object and let the child endpoint methods handle the decoding?

```python
class Endpoint:
    def _get(self, url, params, **kwargs):
        r = requests.get(url, params, **kwargs)
        try:
            r.raise_for_status()
        except requests.HTTPError:
            # Handle different error codes
            raise
        else:
            return r

class Tables(Endpoint):
    def list(self):
        resp = self._get(urljoin(self.base_url, 'list'))
        # it also allows you to access resp.headers (if they are ever useful, idk)
        return resp.json() # or resp.content.decode('utf-8')
```
This last one seems pretty flexible and now when I am thinking about it I like it the most. What do you think?

Travis was passing, so I think it should be OK.