### PR TITLE
refactor Endpoint http methods to _private, return request object

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,6 +5,7 @@ engines:
     enabled: true
     config:
       languages:
-      - python
+        python:
+          python_version: 3
     exclude_paths:
       - tests/      

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+languages:
+  Python: true
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python
+    exclude_paths:
+      - tests/      

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,5 +7,6 @@ engines:
       languages:
         python:
           python_version: 3
+          mass_threshold: 40
     exclude_paths:
       - tests/      

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-test:
-	python -m 'pytest'

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -37,32 +37,39 @@ class Endpoint:
         self.base_url = '{}/v2/storage/{}'.format(root_url.strip('/'),
                                                   path_component.strip('/'))
         self.token = token
+        self._auth_header = {'X-StorageApi-Token': self.token}
 
-    def get(self, *args, **kwargs):
+    def _get(self, url, params=None, **kwargs):
         """
         Construct a requests GET call with args and kwargs and process the
         results.
 
+
         Args:
-            *args: Positional arguments to pass to the get request.
-            **kwargs: Key word arguments to pass to the get request.
+            url (str): requested url
+            params (dict): additional url params to be passed to the underlying
+                requests.get
+            **kwargs: Key word arguments to pass to the get requests.get
 
         Returns:
-            body: Response body parsed from json.
+            r (requests.Response): object
 
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        r = requests.get(*args, **kwargs)
+        headers = kwargs.pop('headers', {})
+        headers.update(self._auth_header)
+
+        r = requests.get(url, params, headers=headers, **kwargs)
         try:
             r.raise_for_status()
         except requests.HTTPError:
             # Handle different error codes
             raise
         else:
-            return r.json()
+            return r
 
-    def post(self, *args, **kwargs):
+    def _post(self, *args, **kwargs):
         """
         Construct a requests POST call with args and kwargs and process the
         results.
@@ -77,16 +84,18 @@ class Endpoint:
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        r = requests.post(*args, **kwargs)
+        headers = kwargs.pop('headers', {})
+        headers.update(self._auth_header)
+        r = requests.post(headers=headers, *args, **kwargs)
         try:
             r.raise_for_status()
         except requests.HTTPError:
             # Handle different error codes
             raise
         else:
-            return r.json()
+            return r
 
-    def delete(self, *args, **kwargs):
+    def _delete(self, *args, **kwargs):
         """
         Construct a requests DELETE call with args and kwargs and process the
         result
@@ -101,7 +110,9 @@ class Endpoint:
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        r = requests.delete(*args, **kwargs)
+        headers = kwargs.pop('headers', {})
+        headers.update(self._auth_header)
+        r = requests.delete(headers=headers, *args, **kwargs)
         try:
             r.raise_for_status()
         except requests.HTTPError:

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -39,7 +39,7 @@ class Endpoint:
         self.token = token
         self._auth_header = {'X-StorageApi-Token': self.token}
 
-    def _get(self, url, params=None, **kwargs):
+    def _get_raw(self, url, params=None, **kwargs):
         """
         Construct a requests GET call with args and kwargs and process the
         results.
@@ -69,9 +69,9 @@ class Endpoint:
         else:
             return r
 
-    def _get_json(self, url, params=None, **kwargs):
+    def _get(self, url, params=None, **kwargs):
         """
-        Make authenticated GET request and return json response
+        Make authenticated GET request and return json
 
         Args:
             url (str): requested url
@@ -86,7 +86,7 @@ class Endpoint:
             requests.HTTPError: If the API request fails.
 
         """
-        return self._get(url, params, **kwargs).json()
+        return self._get_raw(url, params, **kwargs).json()
 
     def _post(self, *args, **kwargs):
         """

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -69,6 +69,25 @@ class Endpoint:
         else:
             return r
 
+    def _get_json(self, url, params=None, **kwargs):
+        """
+        Make authenticated GET request and return json response
+
+        Args:
+            url (str): requested url
+            params (dict): additional url params to be passed to the underlying
+                requests.get
+            **kwargs: Key word arguments to pass to the get requests.get
+
+        Returns:
+            r (requests.Response): object
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+
+        """
+        return self._get(url, params, **kwargs).json()
+
     def _post(self, *args, **kwargs):
         """
         Construct a requests POST call with args and kwargs and process the

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -80,7 +80,7 @@ class Endpoint:
             **kwargs: Key word arguments to pass to the get requests.get
 
         Returns:
-            r (requests.Response): object
+           body: Response body parsed from json.
 
         Raises:
             requests.HTTPError: If the API request fails.

--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -112,7 +112,7 @@ class Endpoint:
             # Handle different error codes
             raise
         else:
-            return r
+            return r.json()
 
     def _delete(self, *args, **kwargs):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -34,7 +34,7 @@ class Buckets(Endpoint):
             requests.HTTPError: If the API request fails.
         """
 
-        return self._get_json(self.base_url)
+        return self._get(self.base_url)
 
     def list_tables(self, bucket_id, include=None):
         """
@@ -55,7 +55,7 @@ class Buckets(Endpoint):
         params = {}
         if include is not None and isinstance(include, list):
             params['include'] = ','.join(include)
-        return self._get_json(url, headers=headers, params=params)
+        return self._get(url, headers=headers, params=params)
 
     def detail(self, bucket_id):
         """
@@ -69,7 +69,7 @@ class Buckets(Endpoint):
         """
         url = '{}/{}'.format(self.base_url, bucket_id)
 
-        return self._get_json(url)
+        return self._get(url)
 
     def create(self, name, stage='in', description='', backend=None):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -34,7 +34,7 @@ class Buckets(Endpoint):
             requests.HTTPError: If the API request fails.
         """
 
-        return self._get(self.base_url).json()
+        return self._get_json(self.base_url)
 
     def list_tables(self, bucket_id, include=None):
         """
@@ -55,7 +55,7 @@ class Buckets(Endpoint):
         params = {}
         if include is not None and isinstance(include, list):
             params['include'] = ','.join(include)
-        return self._get(url, headers=headers, params=params).json()
+        return self._get_json(url, headers=headers, params=params)
 
     def detail(self, bucket_id):
         """
@@ -69,7 +69,7 @@ class Buckets(Endpoint):
         """
         url = '{}/{}'.format(self.base_url, bucket_id)
 
-        return self._get(url).json()
+        return self._get_json(url)
 
     def create(self, name, stage='in', description='', backend=None):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -98,7 +98,7 @@ class Buckets(Endpoint):
             'backend': backend
         }
 
-        return self._post(self.base_url, data=body).json()
+        return self._post(self.base_url, data=body)
 
     def delete(self, bucket_id, force=False):
         """

--- a/kbcstorage/buckets.py
+++ b/kbcstorage/buckets.py
@@ -33,9 +33,8 @@ class Buckets(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
 
-        return self.get(self.base_url, headers=headers)
+        return self._get(self.base_url).json()
 
     def list_tables(self, bucket_id, include=None):
         """
@@ -56,7 +55,7 @@ class Buckets(Endpoint):
         params = {}
         if include is not None and isinstance(include, list):
             params['include'] = ','.join(include)
-        return self.get(url, headers=headers, params=params)
+        return self._get(url, headers=headers, params=params).json()
 
     def detail(self, bucket_id):
         """
@@ -69,9 +68,8 @@ class Buckets(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, bucket_id)
-        headers = {'X-StorageApi-Token': self.token}
 
-        return self.get(url, headers=headers)
+        return self._get(url).json()
 
     def create(self, name, stage='in', description='', backend=None):
         """
@@ -92,10 +90,6 @@ class Buckets(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         # Separating create and link into two distinct functions...
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         # Need to check args...
         body = {
             'name': name,
@@ -104,7 +98,7 @@ class Buckets(Endpoint):
             'backend': backend
         }
 
-        return self.post(self.base_url, headers=headers, data=body)
+        return self._post(self.base_url, data=body).json()
 
     def delete(self, bucket_id, force=False):
         """
@@ -122,9 +116,8 @@ class Buckets(Endpoint):
         # How does the API handle it when force == False and the bucket is non-
         # empty?
         url = '{}/{}'.format(self.base_url, bucket_id)
-        headers = {'X-StorageApi-Token': self.token}
         params = {'force': force}
-        super().delete(url, headers=headers, params=params)
+        self._delete(url, params=params)
 
     def link(self, *args, **kwargs):
         """

--- a/kbcstorage/files.py
+++ b/kbcstorage/files.py
@@ -40,11 +40,10 @@ class Files(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, file_id)
-        headers = {'X-StorageApi-Token': self.token}
         params = {}
         if federation_token:
             params['federationToken'] = 'true'
-        return self.get(url, headers=headers, params=params)
+        return self._get(url, params=params).json()
 
     def upload_file(self, file_path, tags=None, is_public=False,
                     is_permanent=False, is_encrypted=True,
@@ -122,10 +121,6 @@ class Files(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, 'prepare')
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'isPublic': int(is_public),
             'isPermanent': int(is_permanent),
@@ -140,7 +135,7 @@ class Files(Endpoint):
             body['sizeBytes'] = size_bytes
         if federation_token is not None:
             body['federationToken'] = int(federation_token)
-        return self.post(url, headers=headers, data=body)
+        return self._post(url, data=body).json()
 
     def delete(self, file_id):
         """
@@ -150,8 +145,7 @@ class Files(Endpoint):
             file_id (str): The id of the file to be deleted.
         """
         url = '{}/{}'.format(self.base_url, file_id)
-        headers = {'X-StorageApi-Token': self.token}
-        super().delete(url, headers=headers)
+        self._delete(url)
 
     def list(self, limit=100, offset=0, tags=None, q=None, run_id=None,
              since_id=None, max_id=None):
@@ -173,7 +167,6 @@ class Files(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         params = {
             'limit': int(limit),
             'offset': int(offset)
@@ -186,7 +179,7 @@ class Files(Endpoint):
             params['sinceId'] = since_id
         if max_id is not None:
             params['maxId'] = max_id
-        return super().get(self.base_url, headers=headers, params=params)
+        return self._get(self.base_url, params=params).json()
 
     def download(self, file_id, local_path):
         if not os.path.exists(local_path):

--- a/kbcstorage/files.py
+++ b/kbcstorage/files.py
@@ -135,7 +135,7 @@ class Files(Endpoint):
             body['sizeBytes'] = size_bytes
         if federation_token is not None:
             body['federationToken'] = int(federation_token)
-        return self._post(url, data=body).json()
+        return self._post(url, data=body)
 
     def delete(self, file_id):
         """

--- a/kbcstorage/files.py
+++ b/kbcstorage/files.py
@@ -43,7 +43,7 @@ class Files(Endpoint):
         params = {}
         if federation_token:
             params['federationToken'] = 'true'
-        return self._get_json(url, params=params)
+        return self._get(url, params=params)
 
     def upload_file(self, file_path, tags=None, is_public=False,
                     is_permanent=False, is_encrypted=True,
@@ -179,7 +179,7 @@ class Files(Endpoint):
             params['sinceId'] = since_id
         if max_id is not None:
             params['maxId'] = max_id
-        return self._get_json(self.base_url, params=params)
+        return self._get(self.base_url, params=params)
 
     def download(self, file_id, local_path):
         if not os.path.exists(local_path):

--- a/kbcstorage/files.py
+++ b/kbcstorage/files.py
@@ -43,7 +43,7 @@ class Files(Endpoint):
         params = {}
         if federation_token:
             params['federationToken'] = 'true'
-        return self._get(url, params=params).json()
+        return self._get_json(url, params=params)
 
     def upload_file(self, file_path, tags=None, is_public=False,
                     is_permanent=False, is_encrypted=True,
@@ -179,7 +179,7 @@ class Files(Endpoint):
             params['sinceId'] = since_id
         if max_id is not None:
             params['maxId'] = max_id
-        return self._get(self.base_url, params=params).json()
+        return self._get_json(self.base_url, params=params)
 
     def download(self, file_id, local_path):
         if not os.path.exists(local_path):

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -53,7 +53,7 @@ class Jobs(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        return self._get_json(self.base_url)
+        return self._get(self.base_url)
 
     def detail(self, job_id):
         """
@@ -67,7 +67,7 @@ class Jobs(Endpoint):
         """
         url = '{}/{}'.format(self.base_url, job_id)
 
-        return self._get_json(url)
+        return self._get(url)
 
     def status(self, job_id):
         """

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -53,9 +53,7 @@ class Jobs(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
-
-        return self.get(self.base_url, headers=headers)
+        return self._get(self.base_url).json()
 
     def detail(self, job_id):
         """
@@ -67,10 +65,9 @@ class Jobs(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         url = '{}/{}'.format(self.base_url, job_id)
 
-        return self.get(url, headers=headers)
+        return self._get(url).json()
 
     def status(self, job_id):
         """

--- a/kbcstorage/jobs.py
+++ b/kbcstorage/jobs.py
@@ -53,7 +53,7 @@ class Jobs(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        return self._get(self.base_url).json()
+        return self._get_json(self.base_url)
 
     def detail(self, job_id):
         """
@@ -67,7 +67,7 @@ class Jobs(Endpoint):
         """
         url = '{}/{}'.format(self.base_url, job_id)
 
-        return self._get(url).json()
+        return self._get_json(url)
 
     def status(self, job_id):
         """

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -7,10 +7,7 @@ Full documentation `here`.
     http://docs.keboola.apiary.io/#reference/tables/
 """
 import tempfile
-
 import os
-import requests
-
 from kbcstorage.base import Endpoint
 from kbcstorage.files import Files
 from kbcstorage.jobs import Jobs
@@ -42,11 +39,28 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
 
         url = '{}/tables'.format(self.base_url)
         params = {'include': ','.join(include)}
-        return self.get(url, headers=headers, params=params)
+        return self._get(url, params=params).json()
+
+    def list_bucket(self, bucket_id, include=None):
+        """
+        List all tables in a bucket.
+
+        Args:
+            bucket_id (str): Id of the bucket
+            include (list): Properties to list (attributes, columns)
+        Returns:
+            response_body: The parsed json from the HTTP response.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+
+        url = '{}/{}/tables'.format(self.base_url, bucket_id)
+        params = {'include': ','.join(include)}
+        return self._get(url, params=params).json()
 
     def detail(self, table_id):
         """
@@ -61,8 +75,7 @@ class Tables(Endpoint):
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
-        headers = {'X-StorageApi-Token': self.token}
-        return self.get(url, headers=headers)
+        return self._get(url).json()
 
     def delete(self, table_id):
         """
@@ -74,8 +87,7 @@ class Tables(Endpoint):
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
-        headers = {'X-StorageApi-Token': self.token}
-        super().delete(url, headers=headers)
+        self._delete(url)
 
     def create(self, bucket_id, name, file_path, delimiter=',', enclosure='"',
                escaped_by='', primary_key=None):
@@ -143,10 +155,6 @@ class Tables(Endpoint):
             raise ValueError("Invalid bucket_id '{}'.".format(bucket_id))
         if not isinstance(name, str) or name == '':
             raise ValueError("Invalid name_id '{}'.".format(name))
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'name': name,
             'delimiter': delimiter,
@@ -164,7 +172,7 @@ class Tables(Endpoint):
         # todo solve this better
         url = '{}/v2/storage/buckets/{}/tables-async'.format(self.root_url,
                                                              bucket_id)
-        return self.post(url, headers=headers, data=body)
+        return self._post(url, data=body).json()
 
     @staticmethod
     def validate_data_source(data_url, data_file_id, snapshot_id,
@@ -286,10 +294,6 @@ class Tables(Endpoint):
         """
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid file_id '{}'.".format(table_id))
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'delimiter': delimiter,
             'enclosure': enclosure,
@@ -306,7 +310,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             body['primaryKey[]'] = columns
         url = '{}/{}/import-async'.format(self.base_url, table_id)
-        return self.post(url, headers=headers, data=body)
+        return self._post(url, data=body).json()
 
     @staticmethod
     def validate_filter(where_column, where_operator, where_values):
@@ -352,7 +356,6 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         params = {}
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
@@ -371,13 +374,8 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/data-preview'.format(self.base_url, table_id)
-        r = requests.get(url=url, headers=headers, params=params)
-        try:
-            r.raise_for_status()
-        except requests.HTTPError:
-            raise
-        else:
-            return r.content.decode('utf-8')
+        r = self._get(url=url, params=params)
+        return r.content.decode('utf-8')
 
     def export_to_file(self, table_id, path_name, limit=None,
                        file_format='rfc', changed_since=None,
@@ -511,7 +509,6 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         params = {
             'gzip': int(is_gzip)
         }
@@ -536,4 +533,4 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/export-async'.format(self.base_url, table_id)
-        return self.post(url, headers=headers, data=params)
+        return self._post(url, data=params).json()

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -41,7 +41,7 @@ class Tables(Endpoint):
         """
         url = '{}/tables'.format(self.base_url)
         params = {'include': ','.join(include)} if include else {}
-        return self._get_json(url, params=params)
+        return self._get(url, params=params)
 
     def list_bucket(self, bucket_id, include=None):
         """
@@ -59,7 +59,7 @@ class Tables(Endpoint):
 
         url = '{}/{}/tables'.format(self.base_url, bucket_id)
         params = {'include': ','.join(include)} if include else {}
-        return self._get_json(url, params=params)
+        return self._get(url, params=params)
 
     def detail(self, table_id):
         """
@@ -74,7 +74,7 @@ class Tables(Endpoint):
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
-        return self._get_json(url)
+        return self._get(url)
 
     def delete(self, table_id):
         """
@@ -373,7 +373,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/data-preview'.format(self.base_url, table_id)
-        r = self._get(url=url, params=params)
+        r = self._get_raw(url=url, params=params)
         return r.content.decode('utf-8')
 
     def export_to_file(self, table_id, path_name, limit=None,

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -171,7 +171,7 @@ class Tables(Endpoint):
         # todo solve this better
         url = '{}/v2/storage/buckets/{}/tables-async'.format(self.root_url,
                                                              bucket_id)
-        return self._post(url, data=body).json()
+        return self._post(url, data=body)
 
     @staticmethod
     def validate_data_source(data_url, data_file_id, snapshot_id,
@@ -309,7 +309,7 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             body['primaryKey[]'] = columns
         url = '{}/{}/import-async'.format(self.base_url, table_id)
-        return self._post(url, data=body).json()
+        return self._post(url, data=body)
 
     @staticmethod
     def validate_filter(where_column, where_operator, where_values):
@@ -532,4 +532,4 @@ class Tables(Endpoint):
         if columns is not None and isinstance(columns, list):
             params['columns'] = ','.join(columns)
         url = '{}/{}/export-async'.format(self.base_url, table_id)
-        return self._post(url, data=params).json()
+        return self._post(url, data=params)

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -42,24 +42,6 @@ class Tables(Endpoint):
         params = {'include': ','.join(include)} if include else {}
         return self._get(self.base_url, params=params)
 
-    def list_bucket(self, bucket_id, include=None):
-        """
-        List all tables in a bucket.
-
-        Args:
-            bucket_id (str): Id of the bucket
-            include (list): Properties to list (attributes, columns)
-        Returns:
-            response_body: The parsed json from the HTTP response.
-
-        Raises:
-            requests.HTTPError: If the API request fails.
-        """
-
-        url = '{}/{}/tables'.format(self.base_url, bucket_id)
-        params = {'include': ','.join(include)} if include else {}
-        return self._get(url, params=params)
-
     def detail(self, table_id):
         """
         Retrieves information about a given table.

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -42,7 +42,7 @@ class Tables(Endpoint):
 
         url = '{}/tables'.format(self.base_url)
         params = {'include': ','.join(include)}
-        return self._get(url, params=params).json()
+        return self._get_json(url, params=params)
 
     def list_bucket(self, bucket_id, include=None):
         """
@@ -60,7 +60,7 @@ class Tables(Endpoint):
 
         url = '{}/{}/tables'.format(self.base_url, bucket_id)
         params = {'include': ','.join(include)}
-        return self._get(url, params=params).json()
+        return self._get_json(url, params=params)
 
     def detail(self, table_id):
         """
@@ -75,7 +75,7 @@ class Tables(Endpoint):
         if not isinstance(table_id, str) or table_id == '':
             raise ValueError("Invalid table_id '{}'.".format(table_id))
         url = '{}/{}'.format(self.base_url, table_id)
-        return self._get(url).json()
+        return self._get_json(url)
 
     def delete(self, table_id):
         """

--- a/kbcstorage/tables.py
+++ b/kbcstorage/tables.py
@@ -39,9 +39,8 @@ class Tables(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        url = '{}/tables'.format(self.base_url)
         params = {'include': ','.join(include)} if include else {}
-        return self._get(url, params=params)
+        return self._get(self.base_url, params=params)
 
     def list_bucket(self, bucket_id, include=None):
         """

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -52,7 +52,7 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        return self._get(self.base_url).json()
+        return self._get_json(self.base_url)
 
     def detail(self, workspace_id):
         """
@@ -68,7 +68,7 @@ class Workspaces(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, workspace_id)
-        return self._get(url).json()
+        return self._get_json(url)
 
     def create(self, backend=None, timeout=None):
         """

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -88,7 +88,7 @@ class Workspaces(Endpoint):
             'statementTimeoutSeconds': timeout
         }
 
-        return self._post(self.base_url, data=body).json()
+        return self._post(self.base_url, data=body)
 
     def delete(self, workspace_id):
         """
@@ -118,7 +118,7 @@ class Workspaces(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}/password'.format(self.base_url, workspace_id)
-        return self._post(url).json()
+        return self._post(url)
 
     def load_tables(self, workspace_id, table_mapping, preserve=None):
         """
@@ -142,4 +142,4 @@ class Workspaces(Endpoint):
         body['preserve'] = preserve
         url = '{}/{}/load'.format(self.base_url, workspace_id)
 
-        return self._post(url, data=body).json()
+        return self._post(url, data=body)

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -52,7 +52,7 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        return self._get_json(self.base_url)
+        return self._get(self.base_url)
 
     def detail(self, workspace_id):
         """
@@ -68,7 +68,7 @@ class Workspaces(Endpoint):
             requests.HTTPError: If the API request fails.
         """
         url = '{}/{}'.format(self.base_url, workspace_id)
-        return self._get_json(url)
+        return self._get(url)
 
     def create(self, backend=None, timeout=None):
         """

--- a/kbcstorage/workspaces.py
+++ b/kbcstorage/workspaces.py
@@ -52,8 +52,7 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
-        return self.get(self.base_url, headers=headers)
+        return self._get(self.base_url).json()
 
     def detail(self, workspace_id):
         """
@@ -68,9 +67,8 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {'X-StorageApi-Token': self.token}
         url = '{}/{}'.format(self.base_url, workspace_id)
-        return self.get(url, headers=headers)
+        return self._get(url).json()
 
     def create(self, backend=None, timeout=None):
         """
@@ -85,16 +83,12 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = {
             'backend': backend,
             'statementTimeoutSeconds': timeout
         }
 
-        return self.post(self.base_url, data=body, headers=headers)
+        return self._post(self.base_url, data=body).json()
 
     def delete(self, workspace_id):
         """
@@ -108,14 +102,9 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         url = '{}/{}'.format(self.base_url, workspace_id)
 
-        # This shadows the superclass...
-        return super().delete(url, headers=headers)
+        self._delete(url)
 
     def reset_password(self, workspace_id):
         """
@@ -128,12 +117,8 @@ class Workspaces(Endpoint):
         Raises:
             requests.HTTPError: If the API request fails.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         url = '{}/{}/password'.format(self.base_url, workspace_id)
-        return self.post(url, headers=headers)
+        return self._post(url).json()
 
     def load_tables(self, workspace_id, table_mapping, preserve=None):
         """
@@ -153,12 +138,8 @@ class Workspaces(Endpoint):
         Todo:
             * Column data types.
         """
-        headers = {
-            'X-StorageApi-Token': self.token,
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
         body = _make_body(table_mapping)
         body['preserve'] = preserve
         url = '{}/{}/load'.format(self.base_url, workspace_id)
 
-        return self.post(url, data=body, headers=headers)
+        return self._post(url, data=body).json()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -26,7 +26,7 @@ class TestEndpoint(unittest.TestCase):
                          '/v2/storage/not-a-url',
                          endpoint.base_url)
         with self.assertRaises(HTTPError):
-            endpoint.get(endpoint.base_url)
+            endpoint._get(endpoint.base_url)
 
     def test_get_404_2(self):
         endpoint = Endpoint(self.root, '', self.token)
@@ -34,7 +34,7 @@ class TestEndpoint(unittest.TestCase):
                          '/v2/storage/',
                          endpoint.base_url)
         with self.assertRaises(HTTPError):
-            endpoint.get('{}/not-a-url'.format(endpoint.base_url))
+            endpoint._get('{}/not-a-url'.format(endpoint.base_url))
 
     def test_post_404(self):
         """
@@ -42,7 +42,7 @@ class TestEndpoint(unittest.TestCase):
         """
         endpoint = Endpoint(self.root, '', self.token)
         with self.assertRaises(HTTPError):
-            endpoint.post('{}/not-a-url'.format(endpoint.base_url))
+            endpoint._post('{}/not-a-url'.format(endpoint.base_url))
 
     def test_delete_404(self):
         """
@@ -50,4 +50,15 @@ class TestEndpoint(unittest.TestCase):
         """
         endpoint = Endpoint(self.root, 'delete', self.token)
         with self.assertRaises(HTTPError):
-            endpoint.delete('{}/not-a-url'.format(endpoint.base_url))
+            endpoint._delete('{}/not-a-url'.format(endpoint.base_url))
+
+    def test_custom_headers(self):
+        """
+        Passing custom headers to Endpoint._get()
+        """
+        endpoint = Endpoint(self.root, '', self.token)
+        resp = endpoint._get(self.root, headers={'x-foo': 'bar'})
+        request_headers = resp.request.headers
+        self.assertIn('x-foo', request_headers)
+        self.assertIn('X-StorageApi-Token', request_headers)
+        self.assertEqual('bar', request_headers['x-foo'])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -57,7 +57,7 @@ class TestEndpoint(unittest.TestCase):
         Passing custom headers to Endpoint._get()
         """
         endpoint = Endpoint(self.root, '', self.token)
-        resp = endpoint._get(self.root, headers={'x-foo': 'bar'})
+        resp = endpoint._get_raw(self.root, headers={'x-foo': 'bar'})
         request_headers = resp.request.headers
         self.assertIn('x-foo', request_headers)
         self.assertIn('X-StorageApi-Token', request_headers)

--- a/tests/test_functional_files.py
+++ b/tests/test_functional_files.py
@@ -10,7 +10,7 @@ from kbcstorage.files import Files
 from kbcstorage.tables import Tables
 
 
-class TestFunctionalBuckets(unittest.TestCase):
+class TestFunctionalFiles(unittest.TestCase):
     def setUp(self):
         self.files = Files(os.getenv('KBC_TEST_API_URL'),
                            os.getenv('KBC_TEST_TOKEN'))


### PR DESCRIPTION
**This is exactly the same as #32 but rebased + all commits squashed into a big one**, #32 was impossible to merge

--- 
To avoid collisions with the endpoint names and avoid using super().delete(...)
because that is just confusing.

refactor authentication headers handling to Endpoint class
To avoid brutal code duplication. This still allows passing custom headers, to
the child endpoint methods if required.
bug: fix table data-preview made unauthorized requests
remove Makefile
basic endpoint http methods return response object, not json
chore: remove unused import, add missing whitespace
convert line endings to unix to ease merging to master

