### PR TITLE
Rename deprecated function

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -69,7 +69,7 @@ class TestEndpoint(unittest.TestCase):
 
     def test_missing_part(self):
         with self.assertRaisesRegex(ValueError,
-                                     "Path component is required."):
+                                    "Path component is required."):
             Endpoint('https://connection.keboola.com/', '', None)
 
     def test_missing_token(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -64,14 +64,14 @@ class TestEndpoint(unittest.TestCase):
         self.assertEqual('bar', request_headers['x-foo'])
 
     def test_missing_url(self):
-        with self.assertRaisesRegexp(ValueError, "Root URL is required."):
+        with self.assertRaisesRegex(ValueError, "Root URL is required."):
             Endpoint(None, '', None)
 
     def test_missing_part(self):
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      "Path component is required."):
             Endpoint('https://connection.keboola.com/', '', None)
 
     def test_missing_token(self):
-        with self.assertRaisesRegexp(ValueError, "Token is required."):
+        with self.assertRaisesRegex(ValueError, "Token is required."):
             Endpoint('https://connection.keboola.com/', 'tables', None)


### PR DESCRIPTION
`assertRaisesRegexp` was renamed in Python 3.2. This meant the tests were
raising warnings when run. [Link](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaisesRegex).