### PR TITLE
Substests

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -14,27 +14,34 @@ class TestEndpoint(unittest.TestCase):
 
     def test_get(self):
         endpoint = Endpoint(self.root, '/', self.token)
-        self.assertEqual(os.getenv('KBC_TEST_API_URL'), endpoint.root_url)
-        self.assertEqual(os.getenv('KBC_TEST_API_URL') + '/v2/storage/',
-                         endpoint.base_url)
-        self.assertEqual('some-token',
-                         endpoint.token)
+        with self.subTest():
+            self.assertEqual(os.getenv('KBC_TEST_API_URL'), endpoint.root_url)
+        with self.subTest():
+            self.assertEqual(os.getenv('KBC_TEST_API_URL') + '/v2/storage/',
+                             endpoint.base_url)
+        with self.subTest():
+            self.assertEqual('some-token',
+                             endpoint.token)
 
     def test_get_404(self):
         endpoint = Endpoint(self.root, 'not-a-url', self.token)
-        self.assertEqual(os.getenv('KBC_TEST_API_URL') +
-                         '/v2/storage/not-a-url',
-                         endpoint.base_url)
-        with self.assertRaises(HTTPError):
-            endpoint._get(endpoint.base_url)
+        with self.subTest():
+            self.assertEqual(os.getenv('KBC_TEST_API_URL') +
+                             '/v2/storage/not-a-url',
+                             endpoint.base_url)
+        with self.subTest():
+            with self.assertRaises(HTTPError):
+                endpoint._get(endpoint.base_url)
 
     def test_get_404_2(self):
         endpoint = Endpoint(self.root, '/', self.token)
-        self.assertEqual(os.getenv('KBC_TEST_API_URL') +
-                         '/v2/storage/',
-                         endpoint.base_url)
-        with self.assertRaises(HTTPError):
-            endpoint._get('{}/not-a-url'.format(endpoint.base_url))
+        with self.subTest():
+            self.assertEqual(os.getenv('KBC_TEST_API_URL') +
+                             '/v2/storage/',
+                             endpoint.base_url)
+        with self.subTest():
+            with self.assertRaises(HTTPError):
+                endpoint._get('{}/not-a-url'.format(endpoint.base_url))
 
     def test_post_404(self):
         """
@@ -59,9 +66,12 @@ class TestEndpoint(unittest.TestCase):
         endpoint = Endpoint(self.root, '/', self.token)
         resp = endpoint._get_raw(self.root, headers={'x-foo': 'bar'})
         request_headers = resp.request.headers
-        self.assertIn('x-foo', request_headers)
-        self.assertIn('X-StorageApi-Token', request_headers)
-        self.assertEqual('bar', request_headers['x-foo'])
+        with self.subTest():
+            self.assertIn('x-foo', request_headers)
+        with self.subTest():
+            self.assertIn('X-StorageApi-Token', request_headers)
+        with self.subTest():
+            self.assertEqual('bar', request_headers['x-foo'])
 
     def test_missing_url(self):
         with self.assertRaisesRegexp(ValueError, "Root URL is required."):

--- a/tests/test_functional_buckets.py
+++ b/tests/test_functional_buckets.py
@@ -51,21 +51,30 @@ class TestFunctionalBuckets(unittest.TestCase):
         tables.create(name='some-table', file_path=path,
                       bucket_id='in.c-py-test')
         tables = self.buckets.list_tables(bucket_id)
-        self.assertEqual(1, len(tables))
-        self.assertEqual('in.c-py-test.some-table', tables[0]['id'])
+        with self.subTest():
+            self.assertEqual(1, len(tables))
+        with self.subTest():
+            self.assertEqual('in.c-py-test.some-table', tables[0]['id'])
 
     def test_bucket_detail(self):
         bucket_id = self.buckets.create(name='py-test',
                                         stage='in',
                                         description='Test bucket')['id']
         detail = self.buckets.detail(bucket_id)
-        self.assertEqual(bucket_id, detail['id'])
-        self.assertEqual('c-py-test', detail['name'])
-        self.assertIsNotNone(detail['uri'])
-        self.assertIsNotNone(detail['created'])
-        self.assertEqual('Test bucket', detail['description'])
-        self.assertEqual([], detail['tables'])
-        self.assertEqual([], detail['attributes'])
+        with self.subTest():
+            self.assertEqual(bucket_id, detail['id'])
+        with self.subTest():
+            self.assertEqual('c-py-test', detail['name'])
+        with self.subTest():
+            self.assertIsNotNone(detail['uri'])
+        with self.subTest():
+            self.assertIsNotNone(detail['created'])
+        with self.subTest():
+            self.assertEqual('Test bucket', detail['description'])
+        with self.subTest():
+            self.assertEqual([], detail['tables'])
+        with self.subTest():
+            self.assertEqual([], detail['attributes'])
 
     def test_invalid_bucket(self):
         try:

--- a/tests/test_functional_client.py
+++ b/tests/test_functional_client.py
@@ -39,12 +39,17 @@ class TestFunctionalBuckets(unittest.TestCase):
             writer.writeheader()
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         os.close(file)
-        self.assertEqual(bucket_id,
-                         self.client.buckets.detail(bucket_id)['id'])
+        with self.subTest():
+            self.assertEqual(bucket_id,
+                             self.client.buckets.detail(bucket_id)['id'])
         table_id = self.client.tables.create(name='some-table', file_path=path,
                                              bucket_id='in.c-py-test')
         table_info = self.client.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual('in.c-py-test', table_info['bucket']['id'])
-        self.assertTrue(len(self.client.jobs.list()) > 2)
-        self.assertEqual(1, len(self.client.files.list(limit=1)))
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual('in.c-py-test', table_info['bucket']['id'])
+        with self.subTest():
+            self.assertTrue(len(self.client.jobs.list()) > 2)
+        with self.subTest():
+            self.assertEqual(1, len(self.client.files.list(limit=1)))

--- a/tests/test_functional_files.py
+++ b/tests/test_functional_files.py
@@ -31,27 +31,42 @@ class TestFunctionalFiles(unittest.TestCase):
         file_id = self.files.upload_file(path, tags=['py-test', 'file1'])
         os.close(file)
         file_info = self.files.detail(file_id)
-        self.assertEqual(file_id, file_info['id'])
-        self.assertEqual(6, file_info['sizeBytes'])
-        self.assertFalse(file_info['isPublic'])
-        self.assertFalse(file_info['isSliced'])
-        self.assertTrue(file_info['isEncrypted'])
-        self.assertTrue('name' in file_info)
-        self.assertTrue('created' in file_info)
-        self.assertTrue('url' in file_info)
-        self.assertTrue('region' in file_info)
-        self.assertTrue('creatorToken' in file_info)
-        self.assertTrue('tags' in file_info)
-        self.assertTrue('py-test' in file_info['tags'])
-        self.assertTrue('file1' in file_info['tags'])
-        self.assertFalse('credentials' in file_info)
+        with self.subTest():
+            self.assertEqual(file_id, file_info['id'])
+        with self.subTest():
+            self.assertEqual(6, file_info['sizeBytes'])
+        with self.subTest():
+            self.assertFalse(file_info['isPublic'])
+        with self.subTest():
+            self.assertFalse(file_info['isSliced'])
+        with self.subTest():
+            self.assertTrue(file_info['isEncrypted'])
+        with self.subTest():
+            self.assertTrue('name' in file_info)
+        with self.subTest():
+            self.assertTrue('created' in file_info)
+        with self.subTest():
+            self.assertTrue('url' in file_info)
+        with self.subTest():
+            self.assertTrue('region' in file_info)
+        with self.subTest():
+            self.assertTrue('creatorToken' in file_info)
+        with self.subTest():
+            self.assertTrue('tags' in file_info)
+        with self.subTest():
+            self.assertTrue('py-test' in file_info['tags'])
+        with self.subTest():
+            self.assertTrue('file1' in file_info['tags'])
+        with self.subTest():
+            self.assertFalse('credentials' in file_info)
 
     def test_delete_file(self):
         file, path = tempfile.mkstemp(prefix='sapi-test')
         os.write(file, bytes('fooBar', 'utf-8'))
         file_id = self.files.upload_file(path, tags=['py-test', 'file1'])
         os.close(file)
-        self.assertEqual(file_id, self.files.detail(file_id)['id'])
+        with self.subTest():
+            self.assertEqual(file_id, self.files.detail(file_id)['id'])
         self.files.delete(file_id)
         try:
             self.assertEqual(file_id, self.files.detail(file_id)['id'])
@@ -65,11 +80,16 @@ class TestFunctionalFiles(unittest.TestCase):
         file_id = self.files.upload_file(path, tags=['py-test', 'file1'])
         os.close(file)
         file_info = self.files.detail(file_id, federation_token=True)
-        self.assertEqual(file_id, file_info['id'])
-        self.assertTrue('credentials' in file_info)
-        self.assertTrue('AccessKeyId' in file_info['credentials'])
-        self.assertTrue('SecretAccessKey' in file_info['credentials'])
-        self.assertTrue('SessionToken' in file_info['credentials'])
+        with self.subTest():
+            self.assertEqual(file_id, file_info['id'])
+        with self.subTest():
+            self.assertTrue('credentials' in file_info)
+        with self.subTest():
+            self.assertTrue('AccessKeyId' in file_info['credentials'])
+        with self.subTest():
+            self.assertTrue('SecretAccessKey' in file_info['credentials'])
+        with self.subTest():
+            self.assertTrue('SessionToken' in file_info['credentials'])
 
     def test_download_file(self):
         file, path = tempfile.mkstemp(prefix='sapi-test')

--- a/tests/test_functional_tables.py
+++ b/tests/test_functional_tables.py
@@ -42,8 +42,10 @@ class TestFunctionalTables(unittest.TestCase):
         table_id = self.tables.create(name='some-table', file_path=path,
                                       bucket_id='in.c-py-test')
         table_info = self.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual('in.c-py-test', table_info['bucket']['id'])
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual('in.c-py-test', table_info['bucket']['id'])
 
     def test_table_detail(self):
         file, path = tempfile.mkstemp(prefix='sapi-test')
@@ -56,20 +58,33 @@ class TestFunctionalTables(unittest.TestCase):
         table_id = self.tables.create(name='some-table', file_path=path,
                                       bucket_id='in.c-py-test')
         table_info = self.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual('some-table', table_info['name'])
-        self.assertEqual('https://connection.keboola.com/v2/storage/tables/in'
-                         '.c-py-test.some-table', table_info['uri'])
-        self.assertEqual([], table_info['primaryKey'])
-        self.assertEqual([], table_info['indexedColumns'])
-        self.assertEqual(['col1', 'col2'], table_info['columns'])
-        self.assertTrue('created' in table_info)
-        self.assertTrue('lastImportDate' in table_info)
-        self.assertTrue('lastChangeDate' in table_info)
-        self.assertTrue('rowsCount' in table_info)
-        self.assertTrue('metadata' in table_info)
-        self.assertTrue('bucket' in table_info)
-        self.assertTrue('columnMetadata' in table_info)
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual('some-table', table_info['name'])
+        with self.subTest():
+            self.assertEqual('https://connection.keboola.com/v2/storage/tables/in'
+                             '.c-py-test.some-table', table_info['uri'])
+        with self.subTest():
+            self.assertEqual([], table_info['primaryKey'])
+        with self.subTest():
+            self.assertEqual([], table_info['indexedColumns'])
+        with self.subTest():
+            self.assertEqual(['col1', 'col2'], table_info['columns'])
+        with self.subTest():
+            self.assertTrue('created' in table_info)
+        with self.subTest():
+            self.assertTrue('lastImportDate' in table_info)
+        with self.subTest():
+            self.assertTrue('lastChangeDate' in table_info)
+        with self.subTest():
+            self.assertTrue('rowsCount' in table_info)
+        with self.subTest():
+            self.assertTrue('metadata' in table_info)
+        with self.subTest():
+            self.assertTrue('bucket' in table_info)
+        with self.subTest():
+            self.assertTrue('columnMetadata' in table_info)
 
     def test_delete_table(self):
         file, path = tempfile.mkstemp(prefix='sapi-test')
@@ -109,8 +124,10 @@ class TestFunctionalTables(unittest.TestCase):
         table_id = self.tables.create(name='some-table', file_path=path,
                                       bucket_id='in.c-py-test')
         table_info = self.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual(1, table_info['rowsCount'])
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual(1, table_info['rowsCount'])
 
         file, path = tempfile.mkstemp(prefix='sapi-test')
         with open(path, 'w') as csv_file:
@@ -123,8 +140,10 @@ class TestFunctionalTables(unittest.TestCase):
         self.tables.load(table_id=table_id, file_path=path,
                          is_incremental=True)
         table_info = self.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual(2, table_info['rowsCount'])
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual(2, table_info['rowsCount'])
 
     def test_import_table_no_incremental(self):
         file, path = tempfile.mkstemp(prefix='sapi-test')
@@ -138,8 +157,10 @@ class TestFunctionalTables(unittest.TestCase):
         table_id = self.tables.create(name='some-table', file_path=path,
                                       bucket_id='in.c-py-test')
         table_info = self.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual(1, table_info['rowsCount'])
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual(1, table_info['rowsCount'])
 
         file, path = tempfile.mkstemp(prefix='sapi-test')
         with open(path, 'w') as csv_file:
@@ -152,8 +173,10 @@ class TestFunctionalTables(unittest.TestCase):
         self.tables.load(table_id=table_id, file_path=path,
                          is_incremental=False)
         table_info = self.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual(1, table_info['rowsCount'])
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual(1, table_info['rowsCount'])
 
     def test_table_preview(self):
         file, path = tempfile.mkstemp(prefix='sapi-test')
@@ -199,8 +222,10 @@ class TestFunctionalTables(unittest.TestCase):
         table_id = self.tables.create(name='some-table', file_path=path,
                                       bucket_id='in.c-py-test')
         table_info = self.tables.detail(table_id)
-        self.assertEqual(table_id, table_info['id'])
-        self.assertEqual(1, table_info['rowsCount'])
+        with self.subTest():
+            self.assertEqual(table_id, table_info['id'])
+        with self.subTest():
+            self.assertEqual(1, table_info['rowsCount'])
 
         file, path = tempfile.mkstemp(prefix='sapi-test')
         with open(path, 'w') as csv_file:

--- a/tests/test_functional_tables.py
+++ b/tests/test_functional_tables.py
@@ -63,8 +63,9 @@ class TestFunctionalTables(unittest.TestCase):
         with self.subTest():
             self.assertEqual('some-table', table_info['name'])
         with self.subTest():
-            self.assertEqual('https://connection.keboola.com/v2/storage/tables/in'
-                             '.c-py-test.some-table', table_info['uri'])
+            self.assertEqual('https://connection.keboola.com/v2/storage/'
+                             'tables/in.c-py-test.some-table',
+                             table_info['uri'])
         with self.subTest():
             self.assertEqual([], table_info['primaryKey'])
         with self.subTest():


### PR DESCRIPTION
For multiple asserts within a single test fixture we should be using [subtests](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests). Subtests mean that if one assertion fails, the others will still run and you'll get better results from the testrunner.