### PR TITLE
test: Rename bucket created per test module

### DIFF
--- a/tests/functional/test_buckets.py
+++ b/tests/functional/test_buckets.py
@@ -14,7 +14,7 @@ class TestBuckets(unittest.TestCase):
         self.buckets = Buckets(os.getenv('KBC_TEST_API_URL'),
                                os.getenv('KBC_TEST_TOKEN'))
         try:
-            self.buckets.delete('in.c-py-test', force=True)
+            self.buckets.delete('in.c-py-test-buckets', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
@@ -23,19 +23,19 @@ class TestBuckets(unittest.TestCase):
 
     def tearDown(self):
         try:
-            self.buckets.delete('in.c-py-test', force=True)
+            self.buckets.delete('in.c-py-test-buckets', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
 
     def test_create_bucket(self):
-        bucket_id = self.buckets.create(name='py-test',
+        bucket_id = self.buckets.create(name='py-test-buckets',
                                         stage='in',
                                         description='Test bucket')['id']
         self.assertEqual(bucket_id, self.buckets.detail(bucket_id)['id'])
 
     def test_list_tables(self):
-        bucket_id = self.buckets.create(name='py-test',
+        bucket_id = self.buckets.create(name='py-test-buckets',
                                         stage='in',
                                         description='Test bucket')['id']
         file, path = tempfile.mkstemp(prefix='sapi-test')
@@ -49,22 +49,23 @@ class TestBuckets(unittest.TestCase):
         tables = Tables(os.getenv('KBC_TEST_API_URL'),
                         os.getenv('KBC_TEST_TOKEN'))
         tables.create(name='some-table', file_path=path,
-                      bucket_id='in.c-py-test')
+                      bucket_id='in.c-py-test-buckets')
         tables = self.buckets.list_tables(bucket_id)
         with self.subTest():
             self.assertEqual(1, len(tables))
         with self.subTest():
-            self.assertEqual('in.c-py-test.some-table', tables[0]['id'])
+            self.assertEqual('in.c-py-test-buckets.some-table',
+                             tables[0]['id'])
 
     def test_bucket_detail(self):
-        bucket_id = self.buckets.create(name='py-test',
+        bucket_id = self.buckets.create(name='py-test-buckets',
                                         stage='in',
                                         description='Test bucket')['id']
         detail = self.buckets.detail(bucket_id)
         with self.subTest():
             self.assertEqual(bucket_id, detail['id'])
         with self.subTest():
-            self.assertEqual('c-py-test', detail['name'])
+            self.assertEqual('c-py-test-buckets', detail['name'])
         with self.subTest():
             self.assertIsNotNone(detail['uri'])
         with self.subTest():

--- a/tests/functional/test_client.py
+++ b/tests/functional/test_client.py
@@ -13,7 +13,7 @@ class TestClient(unittest.TestCase):
         self.client = Client(os.getenv('KBC_TEST_API_URL'),
                              os.getenv('KBC_TEST_TOKEN'))
         try:
-            self.client.buckets.delete('in.c-py-test', force=True)
+            self.client.buckets.delete('in.c-py-test-client', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
@@ -22,13 +22,13 @@ class TestClient(unittest.TestCase):
 
     def tearDown(self):
         try:
-            self.client.buckets.delete('in.c-py-test', force=True)
+            self.client.buckets.delete('in.c-py-test-client', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
 
     def test_client(self):
-        bucket_id = self.client.buckets.create(name='py-test',
+        bucket_id = self.client.buckets.create(name='py-test-client',
                                                stage='in',
                                                description='Test bucket')['id']
         file, path = tempfile.mkstemp(prefix='sapi-test')
@@ -43,12 +43,12 @@ class TestClient(unittest.TestCase):
             self.assertEqual(bucket_id,
                              self.client.buckets.detail(bucket_id)['id'])
         table_id = self.client.tables.create(name='some-table', file_path=path,
-                                             bucket_id='in.c-py-test')
+                                             bucket_id='in.c-py-test-client')
         table_info = self.client.tables.detail(table_id)
         with self.subTest():
             self.assertEqual(table_id, table_info['id'])
         with self.subTest():
-            self.assertEqual('in.c-py-test', table_info['bucket']['id'])
+            self.assertEqual('in.c-py-test-client', table_info['bucket']['id'])
         with self.subTest():
             self.assertTrue(len(self.client.jobs.list()) > 2)
         with self.subTest():

--- a/tests/functional/test_files.py
+++ b/tests/functional/test_files.py
@@ -106,11 +106,11 @@ class TestFiles(unittest.TestCase):
         buckets = Buckets(os.getenv('KBC_TEST_API_URL'),
                           os.getenv('KBC_TEST_TOKEN'))
         try:
-            buckets.delete('in.c-py-test', force=True)
+            buckets.delete('in.c-py-test-files', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
-        buckets.create(name='py-test', stage='in')
+        buckets.create(name='py-test-files', stage='in')
 
         tables = Tables(os.getenv('KBC_TEST_API_URL'),
                         os.getenv('KBC_TEST_TOKEN'))
@@ -123,7 +123,7 @@ class TestFiles(unittest.TestCase):
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         os.close(file)
         table_id = tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-files')
         file, path = tempfile.mkstemp(prefix='sapi-test')
         with open(path, 'w') as csv_file:
             writer = csv.DictWriter(csv_file, fieldnames=['col1', 'col2'],

--- a/tests/functional/test_tables.py
+++ b/tests/functional/test_tables.py
@@ -15,17 +15,17 @@ class TestTables(unittest.TestCase):
         self.buckets = Buckets(os.getenv('KBC_TEST_API_URL'),
                                os.getenv('KBC_TEST_TOKEN'))
         try:
-            self.buckets.delete('in.c-py-test', force=True)
+            self.buckets.delete('in.c-py-test-tables', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
-        self.buckets.create(name='py-test', stage='in')
+        self.buckets.create(name='py-test-tables', stage='in')
         # https://github.com/boto/boto3/issues/454
         warnings.simplefilter("ignore", ResourceWarning)
 
     def tearDown(self):
         try:
-            self.buckets.delete('in.c-py-test', force=True)
+            self.buckets.delete('in.c-py-test-tables', force=True)
         except exceptions.HTTPError as e:
             if e.response.status_code != 404:
                 raise
@@ -40,12 +40,12 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         table_info = self.tables.detail(table_id)
         with self.subTest():
             self.assertEqual(table_id, table_info['id'])
         with self.subTest():
-            self.assertEqual('in.c-py-test', table_info['bucket']['id'])
+            self.assertEqual('in.c-py-test-tables', table_info['bucket']['id'])
 
     def test_table_detail(self):
         file, path = tempfile.mkstemp(prefix='sapi-test')
@@ -56,7 +56,7 @@ class TestTables(unittest.TestCase):
             writer.writeheader()
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         table_info = self.tables.detail(table_id)
         with self.subTest():
             self.assertEqual(table_id, table_info['id'])
@@ -64,7 +64,7 @@ class TestTables(unittest.TestCase):
             self.assertEqual('some-table', table_info['name'])
         with self.subTest():
             self.assertEqual('https://connection.keboola.com/v2/storage/'
-                             'tables/in.c-py-test.some-table',
+                             'tables/in.c-py-test-tables.some-table',
                              table_info['uri'])
         with self.subTest():
             self.assertEqual([], table_info['primaryKey'])
@@ -96,7 +96,7 @@ class TestTables(unittest.TestCase):
             writer.writeheader()
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         table_info = self.tables.detail(table_id)
         self.assertEqual(table_id, table_info['id'])
         self.tables.delete(table_id)
@@ -123,7 +123,7 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         table_info = self.tables.detail(table_id)
         with self.subTest():
             self.assertEqual(table_id, table_info['id'])
@@ -156,7 +156,7 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         table_info = self.tables.detail(table_id)
         with self.subTest():
             self.assertEqual(table_id, table_info['id'])
@@ -190,7 +190,7 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'foo', 'col2': 'bar'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         contents = self.tables.preview(table_id=table_id)
         lines = contents.split('\n')
         self.assertEqual(['', '"col1","col2"', '"foo","bar"', '"ping","pong"'],
@@ -207,7 +207,7 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'foo', 'col2': 'bar'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         result = self.tables.export(table_id=table_id)
         self.assertIsNotNone(result)
 
@@ -221,7 +221,7 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'ping', 'col2': 'pong'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         table_info = self.tables.detail(table_id)
         with self.subTest():
             self.assertEqual(table_id, table_info['id'])

--- a/tests/functional/test_tables.py
+++ b/tests/functional/test_tables.py
@@ -222,7 +222,7 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'foo', 'col2': 'bar'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         temp_path = tempfile.TemporaryDirectory()
         local_path = self.tables.export_to_file(table_id=table_id,
                                                 path_name=temp_path.name,
@@ -244,7 +244,7 @@ class TestTables(unittest.TestCase):
             writer.writerow({'col1': 'foo', 'col2': 'bar'})
         os.close(file)
         table_id = self.tables.create(name='some-table', file_path=path,
-                                      bucket_id='in.c-py-test')
+                                      bucket_id='in.c-py-test-tables')
         temp_path = tempfile.TemporaryDirectory()
         local_path = self.tables.export_to_file(table_id=table_id,
                                                 path_name=temp_path.name,


### PR DESCRIPTION
This way, test modules can be run concurrently without fear of collisions on the bucket name. I use [green](https://github.com/CleanCut/green) which uses multiprocessing to run my tests, so I often have failures because of the bucket being deleted by one test case when it is needed by another test case.

This doesn't prevent collision by two users testing in the same workspace at the same time, however. That would probably require adding a UUID to the bucket name or something...