### PR TITLE
[AIS-48] fix project versioning with pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .env
 /.coverage
 /kbcstorage.egg-info
+/dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -28,3 +28,6 @@ dependencies = [
     "python-dotenv",
 ]
 dynamic = ["version"]
+
+[tool.setuptools-git-versioning]
+enabled = true


### PR DESCRIPTION
This should read the package version as the latest git tag