### PR TITLE
Remove outdated urllib3<2.0.0 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 dependencies = [
     "boto3",
     "azure-storage-blob",
-    "urllib3<2.0.0",  # Frozen until fixed: https://github.com/boto/botocore/issues/2926
     # Dev dependencies
     "requests",
     "responses",


### PR DESCRIPTION
## Summary

- Remove the direct `urllib3<2.0.0` constraint from `pyproject.toml`
- The pin was a workaround for [boto/botocore#2926](https://github.com/boto/botocore/issues/2926), which has been resolved
- Current botocore (1.42.x) manages its own urllib3 constraints via Python version markers (`urllib3<1.27` for Python <3.10, `urllib3>=1.25.4,<3` for Python >=3.10)
- kbcstorage does not import or use urllib3 directly — the pin is unnecessary
- The constraint blocks downstream projects from resolving modern versions of urllib3 and related packages

Closes #91